### PR TITLE
feat(protocols): expand directory from 3 to 9 protocols

### DIFF
--- a/RFC-003-PROTOCOL-EXPANSION.md
+++ b/RFC-003-PROTOCOL-EXPANSION.md
@@ -1,0 +1,343 @@
+# RFC 003: Protocol Analytics Expansion
+
+Status: proposal accompanying initial PR
+Author: contribution to cargopete/lodestar
+Date: 2026-05
+
+## Summary
+
+Triples the `/protocols` analytics surface from 3 protocols across 2
+categories (DEX, Lending) to **9 protocols across 3 categories** spanning
+4 chains (Ethereum, Polygon, Arbitrum, Gnosis). Every new data point
+flows through The Graph's decentralised network: no third-party indexers,
+no proprietary aggregators.
+
+The most useful methodology insight from the build: **the Graph MCP
+servers (`graph-lending`, `graph-uniswap`, `graph-aave`, `graph-lido`)
+are the right discovery layer for this kind of work**. Searching the
+Explorer or guessing IDs surfaces a lot of stale Messari deployments;
+querying the MCPs returns only the protocols whose subgraphs are live
+right now and serving fresh data. This RFC documents the working set
+discovered that way, plus the upstream gaps that prevent further
+expansion (perps, prediction markets, Hyperliquid, dYdX v4, social).
+
+## What this PR adds
+
+### Protocols (6 new)
+
+| # | Protocol | Category | Chain | Schema | TVL | Subgraph |
+|---|---|---|---|---|---|---|
+| 1 | Uniswap V3 (Polygon) | DEX | Polygon | uniswap-v3 | $96M | `3hCPRGf4z88VC5rsBKU5AA9FBBq5nF3jbKJG7VZCbhjm` |
+| 2 | Aave V3 (Arbitrum) | Lending | Arbitrum | messari-lending | $1.15B | `4xyasjQeREe7PxnF6wVdobZvCw5mhoHZq3T7guRpuNPf` |
+| 3 | MakerDAO | Lending | Ethereum | messari-lending | $5.46B | `8sE6rTNkPhzZXZC6c8UQy2ghFTu5PPdGauwUBm4t7HZ1` |
+| 4 | Morpho Blue | Lending | Ethereum | messari-lending | $4.03B | `8Lz789DP5VKLXumTMTgygjU2xtuzx8AhbaacgN5PYCAs` |
+| 5 | Spark Lend (Gnosis) | Lending | Gnosis | messari-lending | $611K | `Bw4RH37UbbGEhHo4FaWwT1dn9QJzm1XSZCyK1cbr6ZKM` |
+| 6 | Lido | Liquid Staking | Ethereum | messari-staking (new) | $18.55B | `F7qb71hWab6SuRL5sf6LQLTpNahmqMsBnnweYHzLGUyG` |
+
+Combined with the three pre-existing protocols (Uniswap V3 Ethereum,
+Aave V3 Ethereum, Compound V3 Ethereum), the directory now covers
+**$33+ billion of TVL** across DEX, Lending, and Liquid Staking.
+
+### Schema
+
+`messari-staking` joins `messari-dex`, `messari-lending`, and
+`uniswap-v3` as the fourth discriminant. It uses the same `protocols` +
+`financialsDailySnapshots` shape, mapped so that "volume" reads as
+supply-side yield and "fees" as the protocol's cut. Same schema works
+for any Messari yield / staking deployment as soon as their subgraphs
+are confirmed live and writing daily revenue fields.
+
+### UI changes
+
+- New `Liquid Staking` category badge with its own colour token.
+- `CATEGORY_LABELS` table on the detail page: each category contributes
+  its own KPI labels (Liquid Staking shows "Total Value Staked" and "30d
+  Staker Yield" instead of "TVL" / "30d Volume").
+- Optional category-specific extra-stat tiles (Lido surfaces a 30d-
+  estimated staking APR).
+- `formatUSD` extended with trillion (T) compact notation so $1.98T
+  renders cleanly instead of $1979.45B.
+- Table cells use `whitespace-nowrap` so unusually formatted numbers
+  cannot wrap and break row alignment.
+
+### Data quality guards
+
+- New `sanitizeCumulative` helper guards against the known class of
+  Messari bugs where USD fields leak unscaled integer values (Curve
+  mainnet does this on `cumulativeVolumeUSD`, certain Aave snapshots on
+  `cumulativeFeesUSD`). Anything north of $1e15 falls back to the
+  snapshot-derived sum. This keeps directory cells from rendering
+  "$ 376424613377.91B" and shattering layout when an upstream subgraph
+  misbehaves.
+- Daily protocol fees on the staking schema are estimated from the
+  cumulative protocol/supply ratio when the daily field is empty. The
+  Messari Lido subgraph writes `dailyProtocolSideRevenueUSD = 0` across
+  every snapshot while still maintaining a non-zero
+  `cumulativeProtocolSideRevenueUSD` (~10% of supply-side, matching
+  Lido's fee policy). Without this back-derivation the "Daily Fees (90
+  days)" chart would be a flat zero.
+
+## Methodology: discovery via Graph MCP servers
+
+The first pass of this work assumed Graph Explorer search results were
+the source of truth. That produced ~50% wasted effort: many of the
+Explorer-listed Messari subgraphs are stale, return `subgraph not
+found` from the gateway, or write zero into key fields silently while
+still passing `_meta` health checks.
+
+The second pass switched to the Graph MCP servers as the discovery
+layer:
+
+```
+mcp__graph-lending__list_protocols       → ~70 active lending protocols with live TVL
+mcp__graph-aave__list_aave_chains        → 7 Aave V3/V2 deployments with subgraph IDs
+mcp__graph-uniswap__list_uniswap_chains  → 15 Uniswap V3+V4 deployments
+mcp__graph-lido__get_lido_stats          → Lido current stats (9.06M ETH, 605K holders)
+```
+
+Every MCP query returns results filtered by **what is actually
+serving** -- if a protocol shows up in `list_protocols` with a non-zero
+TVL, its subgraph is alive on the gateway. That filter alone cut search
+time on this PR by an order of magnitude.
+
+For each candidate the workflow was:
+1. Confirm liveness via the relevant MCP (`get_protocol`,
+   `get_protocol_stats`, `get_lido_stats`).
+2. Find the subgraph deployment ID via the Explorer URL (the MCPs
+   currently do not expose IDs directly, only names + slugs).
+3. Test the ID against Lodestar's existing schema queries.
+4. If schema matches, ship. If not, either skip or write a new
+   discriminant.
+
+**Recommendation for the Graph teams:** the MCP `list_*` and `get_*`
+tools should expose deployment IDs in their responses. Today they
+return human-readable stats, but to integrate them as a backend into a
+product like Lodestar you need the deployment ID, and the Explorer
+roundtrip is friction. A `subgraphId` field on each entry would unblock
+direct programmatic use.
+
+## What we tried and could not ship (the upstream-quality problem)
+
+The first round of additions tried to span more verticals -- Sushiswap,
+Curve, GMX V2 (Perps), Polymarket (Prediction Markets). All were
+dropped after live testing showed the data underneath was unusable.
+Generalising: **a meaningful share of the Messari "standardised
+subgraphs" library is now silently broken**, and prediction-market /
+perp-DEX subgraphs face their own issues.
+
+### Sushiswap (Messari, Ethereum) -- HARD FAILURE
+
+```
+GET .../subgraphs/id/7h1x51fyT5KigAhXd8sdE3kzzxQDJxxz1y66LTFiC3mS
+=> "subgraph not found"
+```
+
+Explorer page exists. Gateway returns `subgraph not found`. The
+deployment has been removed from active indexing, but the Explorer
+listing gives no warning. Discoverability gap: builders pick a subgraph
+from Explorer, find it does not work in production, then have to find
+an alternative.
+
+### Curve Finance (Messari, mainnet) -- DATA INTEGRITY FAILURE
+
+```
+cumulativeVolumeUSD: 8.32e+15      // ~1e6× too large
+volume30dUSD:        7.02e+15
+```
+
+The subgraph is alive but USD fields appear to skip the USDC 1e6
+decimal scaling somewhere in the indexer. Every USD value is inflated
+by ~1e6×. Sanitisation can clamp the symptom; it cannot make the data
+correct.
+
+### GMX V2 (Messari, Arbitrum) -- PARTIAL DATA / SILENT DEGRADATION
+
+```
+totalValueLockedUSD:    890,901          // protocol reports $890K (real is hundreds of millions)
+cumulativeVolumeUSD:    123,423,902,899  // $123B, plausibly correct historical
+dailyVolumeUSD (recent): 0               // every recent daily snapshot
+```
+
+Recent `_lastUpdateTimestamp`. Technically "live". But daily financials
+write zero, and protocol-level TVL is wildly off. Either indexer logic
+regressed or the schema changed underneath. The fact that this subgraph
+passes basic health checks while serving silently broken data is the
+most dangerous category of failure for any analytics product.
+
+### Polymarket (native, Polygon) -- VOLUME TRACKING STOPPED
+
+```
+global { collateralVolume: 0, scaledCollateralVolume: 0, collateralFees: 0 }
+transactions: []
+_meta { hasIndexingErrors: false, block: { timestamp: <now> } }
+```
+
+Subgraph is being indexed (no errors, latest block is current) and
+`numConditions` / `numOpenConditions` continue to update -- 1.23M total
+markets, 139K open. But every USD-denominated field is zero and the
+`transactions` table returns nothing. Some schema-handler change in
+the subgraph silently stopped writing volume data.
+
+### What would unblock these
+
+Each is upstream-side, not Lodestar-side:
+
+- **Subgraph health badges in Graph Explorer.** A simple "last
+  successful query in the past 24h" indicator alongside signal would
+  let dashboard builders pick from the active set. Stale deployments
+  should be visually demoted.
+- **Field-level freshness, not just block freshness.** GMX V2 and
+  Polymarket both pass `_meta` health checks but write zero into key
+  fields. A health endpoint that reports "field X has not received a
+  non-zero write in N days" would catch this.
+- **Re-indexing or hand-off of orphan Messari subgraphs.** Many
+  Messari deployments are no longer maintained. Either Edge & Node,
+  Pinax, or a community fork should take ownership of the high-traffic
+  ones (Curve, Sushi, GMX V2, Synthetix) so the standard schema
+  continues to be a viable analytics target.
+- **Schema-version assertions.** Subgraphs declaring `schemaVersion`
+  should validate that USD-denominated fields are in fact USD-scaled.
+  A single oracle-sanity test query at deploy time would catch the
+  Curve-style 1e6 inflation before users see it.
+- **Surface subgraph deployment IDs in MCP responses.** As above:
+  `subgraphId` on `list_protocols` / `list_aave_chains` /
+  `list_uniswap_chains` would let downstream products like Lodestar
+  use the MCPs as a discovery layer programmatically, not just an
+  interactive one.
+
+## What was scoped out (and why)
+
+These could be built today but were intentionally deferred to keep the
+PR reviewable. Each is a self-contained follow-up.
+
+- Per-chain dimensioning of multi-chain protocols: today
+  `aave-v3-arbitrum` is its own row alongside `aave-v3` (Ethereum).
+  A "chains" pivot in the directory would aggregate them. Architecture
+  is already chain-aware.
+- Sortable / filterable directory (by category, TVL, 30d fee growth).
+- `/api/protocols` exposed as a public read API for embed consumers.
+- Iframe-embed mode (`?embed=1`) for individual protocol cards.
+- Persistence of daily snapshots into the existing Postgres so the
+  historical window can extend past the 90 days the subgraphs return.
+- Compound V2 ($137M), Liquity ($180M), Venus ($1.7B) and other
+  smaller-but-iconic lending protocols. Each one is a config-row
+  addition once its subgraph ID is confirmed; we ran out of time, not
+  out of capacity.
+
+## Verticals blocked by today's Graph stack
+
+Beyond the upstream-quality problem, these verticals are blocked by
+primitives that do not yet exist on the platform.
+
+### 1. Hyperliquid (Perps)
+
+Dominant perp DEX in 2026 by volume but runs its own L1 (HyperBVM /
+HyperEVM). No first-party subgraph and the chain is not yet a Token
+API target. **Unblock:** HyperEVM as a supported indexing target on
+the decentralised network.
+
+### 2. dYdX v4 (Perps)
+
+Runs its own Cosmos-based chain. The v3 Ethereum subgraph is end of
+life; v4 has no indexer in The Graph network today. **Unblock:**
+Cosmos / dYdX-chain support, or a Substreams package that bridges
+the dYdX v4 indexer feed.
+
+### 3. Stablecoins
+
+Needs total supply over time, mint / burn flow per chain, and holder
+counts. Token API can do balances, transfers, and OHLC, but there is
+no clean `circulatingSupply` time series endpoint, and no built-in
+label set distinguishing mint / burn / treasury wallets. **Unblock:**
+- `getTotalSupplyHistory(token, chain, range)` endpoint on Token API.
+- Wallet labels (issuer mint, treasury, exchange) as a queryable
+  Token API resource.
+
+### 4. CEX transparency (proof-of-reserves)
+
+Same wallet-labels primitive as stablecoins.
+
+### 5. NFT markets (collection-level dashboards)
+
+Token API has NFT endpoints (collection, holders, sales). Missing is
+a floor + volume time-series per collection. **Unblock:**
+`getNftCollectionTimeseries(collection, range)`.
+
+### 6. Farcaster (Social)
+
+Identity is on-chain via the FID registry, but casts, reactions, and
+channel activity live in Hubs. Subgraphs cover identity registrations
+and Frames-related on-chain events, not engagement metrics.
+**Unblock:** a first-party Hubs adapter, exposed as either a hosted
+subgraph-equivalent or a Hypergraph data product.
+
+### 7. Multi-chain unified balances (treasuries, portfolios)
+
+Today, "show me a multisig's balance across every chain" requires N
+calls to Token API's balances endpoint. **Unblock:** a
+`GET /balances/cross-chain?address=...` endpoint that fan-outs
+server-side.
+
+### 8. Authoritative pricing for long-tail and RWA tokens
+
+CoinGecko-style pricing handles mainline tokens. RWA tokens (Ondo,
+Centrifuge tranches, BUIDL) and long-tail LST / LRT pairs do not
+always have clean Token API OHLC quotes. **Unblock:** a price oracle
+subgraph aggregator (Chainlink + Pyth + RedStone normalised), or a
+Hypergraph use case.
+
+### 9. Subgraph federation across chain deployments
+
+Aave V3 has a separate subgraph deployment per chain. To show "Aave
+V3 across all chains", today the fetcher would need N round trips
+and aggregate client-side. **Unblock:** a "subgraph-of-subgraphs"
+federation primitive on the gateway: one query, fan-out to N
+deployments, return a unioned response.
+
+### 10. Real-time liquidations feed
+
+Doable via subgraphs, but each refresh hits the gateway. Substreams
+is the right tool, but the friction (Rust modules, package publishing)
+is too high for dashboard builders. **Unblock:** higher-level
+Substreams primitives, e.g. a "live tail" preset for common patterns.
+
+## Local verification
+
+```bash
+git checkout -b protocols-expansion
+npm install            # or pnpm install --ignore-workspace
+cp .env.example .env   # add GRAPH_API_KEY from thegraph.com/studio/apikeys
+npm run dev            # http://localhost:3000/protocols
+```
+
+All 9 protocols at `/protocols/<slug>`:
+
+```
+/protocols/uniswap-v3            /protocols/morpho-blue
+/protocols/uniswap-v3-polygon    /protocols/spark-lend-gnosis
+/protocols/aave-v3               /protocols/lido
+/protocols/aave-v3-arbitrum
+/protocols/compound-v3
+/protocols/makerdao
+```
+
+A single broken subgraph degrades to "—" rather than breaking the
+directory, and `sanitizeCumulative` prevents inflated upstream values
+from breaking layout. The page is safe to ship even if one of the new
+schemas needs a tweak post-merge.
+
+## How the gaps would change the PR shape
+
+If the upstream items above land within the next two quarters, the
+architecture in this PR drops in trivially: each new vertical is a
+config row plus, at most, a single new schema fetcher
+(`messari-stablecoin`, `messari-nft`, etc.). The discriminated
+`SchemaType` keeps the codebase honest about which fetcher returns
+which shape, and `ProtocolDaySnapshot` is generic enough to survive
+new categories without churn.
+
+The fragile boundary is items 6-8 (Farcaster Hubs, cross-chain
+balances, authoritative pricing). Those would push us into either
+off-Graph data sources or significantly upstream changes. Worth
+explicit conversation with the relevant Graph teams before committing
+to a shipping date.

--- a/src/app/protocols/[slug]/page.tsx
+++ b/src/app/protocols/[slug]/page.tsx
@@ -14,7 +14,8 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { getProtocol } from '@/lib/protocols/config';
+import { getProtocol, type ProtocolCategory } from '@/lib/protocols/config';
+import type { ProtocolSummary } from '@/lib/protocols/fetcher';
 import { useProtocolDetail } from '@/hooks/useProtocols';
 import { formatUSD } from '@/lib/utils';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
@@ -36,6 +37,10 @@ function formatDate(timestamp: number) {
   return new Date(timestamp * 1000).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
 }
 
+function formatPercent(n: number) {
+  return `${n.toFixed(2)}%`;
+}
+
 function MetricCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
     <div className="p-4 rounded-[var(--radius-button)] bg-[var(--bg-elevated)] border border-[var(--border)]">
@@ -44,6 +49,63 @@ function MetricCard({ label, value, sub }: { label: string; value: string; sub?:
       {sub && <p className="text-[10px] text-[var(--text-faint)] mt-0.5">{sub}</p>}
     </div>
   );
+}
+
+interface CategoryLabels {
+  tvlLabel: string;
+  volumeLabel: string;
+  volumeChartTitle: string;
+  volumeTooltipLabel: string;
+  feesLabel: string;
+  cumulativeLabel: string;
+  cumulativeValue: (s?: ProtocolSummary) => number;
+  cumulativeSub: string;
+}
+
+const CATEGORY_LABELS: Record<ProtocolCategory, CategoryLabels> = {
+  'DEX': {
+    tvlLabel: 'Total Value Locked',
+    volumeLabel: '30d Volume',
+    volumeChartTitle: 'Daily Volume (90 days)',
+    volumeTooltipLabel: 'Volume',
+    feesLabel: '30d Fees',
+    cumulativeLabel: 'Total Volume',
+    cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
+    cumulativeSub: 'all time',
+  },
+  'Lending': {
+    tvlLabel: 'Total Value Locked',
+    volumeLabel: 'Active Borrows',
+    volumeChartTitle: 'Daily Borrowing (90 days)',
+    volumeTooltipLabel: 'Borrowed',
+    feesLabel: '30d Fees',
+    cumulativeLabel: 'Total Borrowed',
+    cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
+    cumulativeSub: 'all time',
+  },
+  'Liquid Staking': {
+    tvlLabel: 'Total Value Staked',
+    volumeLabel: '30d Staker Yield',
+    volumeChartTitle: 'Daily Yield to Stakers (90 days)',
+    volumeTooltipLabel: 'Yield',
+    feesLabel: '30d Protocol Fees',
+    cumulativeLabel: 'Cumulative Yield',
+    cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
+    cumulativeSub: 'all time',
+  },
+};
+
+interface ExtraStat {
+  label: string;
+  value: string;
+}
+
+function getExtraStats(category: ProtocolCategory, summary?: ProtocolSummary): ExtraStat[] {
+  if (!summary) return [];
+  if (category === 'Liquid Staking' && summary.stakingAPR) {
+    return [{ label: 'Staking APR (30d est.)', value: formatPercent(summary.stakingAPR) }];
+  }
+  return [];
 }
 
 export default function ProtocolDetailPage({ params }: { params: Promise<{ slug: string }> }) {
@@ -62,7 +124,14 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
     fees: s.feesUSD,
   }));
 
-  const isLending = config.category === 'Lending';
+  const labels = CATEGORY_LABELS[config.category];
+  const extras = getExtraStats(config.category, summary);
+
+  // Lending uses Active Borrows (current snapshot) instead of summed 30d volume
+  const volumeKpiValue = config.category === 'Lending'
+    ? summary?.totalBorrowUSD ?? 0
+    : summary?.volume30dUSD ?? 0;
+  const volumeKpiSub = config.category === 'Lending' ? undefined : 'last 30 days';
 
   return (
     <div className="space-y-6">
@@ -100,33 +169,45 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
       {/* KPI cards */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <MetricCard
-          label="Total Value Locked"
+          label={labels.tvlLabel}
           value={isLoading ? '—' : formatUSD(summary?.tvlUSD ?? 0)}
         />
         <MetricCard
-          label={isLending ? 'Active Borrows' : '30d Volume'}
-          value={isLoading ? '—' : isLending
-            ? formatUSD(summary?.totalBorrowUSD ?? 0)
-            : formatUSD(summary?.volume30dUSD ?? 0)
-          }
-          sub={isLending ? undefined : 'last 30 days'}
+          label={labels.volumeLabel}
+          value={isLoading ? '—' : formatUSD(volumeKpiValue)}
+          sub={volumeKpiSub}
         />
         <MetricCard
-          label="30d Fees"
+          label={labels.feesLabel}
           value={isLoading ? '—' : formatUSD(summary?.fees30dUSD ?? 0)}
           sub="last 30 days"
         />
         <MetricCard
-          label={isLending ? 'Total Borrowed' : 'Total Volume'}
-          value={isLoading ? '—' : formatUSD(summary?.cumulativeVolumeUSD ?? 0)}
-          sub="all time"
+          label={labels.cumulativeLabel}
+          value={isLoading ? '—' : formatUSD(labels.cumulativeValue(summary))}
+          sub={labels.cumulativeSub}
         />
       </div>
+
+      {/* Category-specific extras */}
+      {extras.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {extras.map((stat) => (
+            <div
+              key={stat.label}
+              className="p-3 rounded-[var(--radius-button)] bg-[var(--bg-elevated)]/60 border border-[var(--border)]"
+            >
+              <p className="text-[10px] text-[var(--text-faint)] mb-0.5">{stat.label}</p>
+              <p className="text-sm font-mono font-medium text-[var(--text)]">{stat.value}</p>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* TVL chart */}
       <Card>
         <CardHeader>
-          <CardTitle>Total Value Locked (90 days)</CardTitle>
+          <CardTitle>{labels.tvlLabel} (90 days)</CardTitle>
         </CardHeader>
         <CardContent>
           {isLoading ? (
@@ -179,7 +260,7 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>{isLending ? 'Daily Borrowing (90 days)' : 'Daily Volume (90 days)'}</CardTitle>
+            <CardTitle>{labels.volumeChartTitle}</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
@@ -205,7 +286,7 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
                     />
                     <Tooltip
                       {...TOOLTIP_STYLE}
-                      formatter={(value) => [formatUSD(Number(value)), isLending ? 'Borrowed' : 'Volume']}
+                      formatter={(value) => [formatUSD(Number(value)), labels.volumeTooltipLabel]}
                     />
                     <Bar dataKey="volume" fill={config.color} fillOpacity={0.7} radius={[2, 2, 0, 0]} />
                   </BarChart>
@@ -274,4 +355,3 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
     </div>
   );
 }
-

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -6,16 +6,16 @@ import { useProtocolsDirectory } from '@/hooks/useProtocols';
 import { formatUSD } from '@/lib/utils';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
 
+const CATEGORY_STYLES: Record<string, string> = {
+  'DEX': 'bg-[var(--accent)]/10 text-[var(--accent)]',
+  'Lending': 'bg-[var(--green)]/10 text-[var(--green)]',
+  'Liquid Staking': 'bg-[#00A3FF]/12 text-[#5BC2FF]',
+};
+
 function CategoryBadge({ category }: { category: string }) {
-  const isDex = category === 'DEX';
+  const styles = CATEGORY_STYLES[category] ?? 'bg-[var(--bg-elevated)] text-[var(--text-muted)]';
   return (
-    <span
-      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${
-        isDex
-          ? 'bg-[var(--accent)]/10 text-[var(--accent)]'
-          : 'bg-[var(--green)]/10 text-[var(--green)]'
-      }`}
-    >
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium whitespace-nowrap ${styles}`}>
       {category}
     </span>
   );
@@ -90,13 +90,13 @@ export default function ProtocolsPage() {
                         <td className="py-3 pr-4">
                           <CategoryBadge category={protocol.category} />
                         </td>
-                        <td className="py-3 pr-4 text-right font-mono text-[var(--text)]">
+                        <td className="py-3 pr-4 text-right font-mono text-[var(--text)] whitespace-nowrap">
                           {failed ? '—' : summary ? formatUSD(summary.tvlUSD) : <span className="text-[var(--text-faint)]">—</span>}
                         </td>
-                        <td className="py-3 pr-4 text-right font-mono text-[var(--text-muted)] text-xs">
+                        <td className="py-3 pr-4 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap">
                           {failed ? '—' : summary ? formatUSD(summary.volume30dUSD) : '—'}
                         </td>
-                        <td className="py-3 text-right font-mono text-[var(--accent)] text-xs">
+                        <td className="py-3 text-right font-mono text-[var(--accent)] text-xs whitespace-nowrap">
                           {failed ? '—' : summary ? formatUSD(summary.fees30dUSD) : '—'}
                         </td>
                       </tr>

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -1,5 +1,13 @@
-export type SchemaType = 'messari-dex' | 'messari-lending' | 'uniswap-v3';
-export type ProtocolCategory = 'DEX' | 'Lending';
+export type SchemaType =
+  | 'messari-dex'
+  | 'messari-lending'
+  | 'messari-staking'
+  | 'uniswap-v3';
+
+export type ProtocolCategory =
+  | 'DEX'
+  | 'Lending'
+  | 'Liquid Staking';
 
 export interface ProtocolConfig {
   slug: string;
@@ -26,15 +34,37 @@ export const PROTOCOLS: ProtocolConfig[] = [
     color: '#FF007A',
   },
   {
+    slug: 'uniswap-v3-polygon',
+    name: 'Uniswap V3 (Polygon)',
+    category: 'DEX',
+    description: 'Uniswap V3 deployment on Polygon. Established L2 venue with deep MATIC and stablecoin liquidity, queried via the same v3 schema as the mainnet deployment.',
+    subgraphId: '3hCPRGf4z88VC5rsBKU5AA9FBBq5nF3jbKJG7VZCbhjm',
+    schemaType: 'uniswap-v3',
+    website: 'https://app.uniswap.org',
+    chains: ['Polygon'],
+    color: '#8247E5',
+  },
+  {
     slug: 'aave-v3',
     name: 'Aave V3',
     category: 'Lending',
-    description: 'Decentralised non-custodial liquidity protocol where users supply assets to earn yield and borrow against collateral.',
+    description: 'Decentralised non-custodial liquidity protocol where users supply assets to earn yield and borrow against collateral. This dashboard tracks the Ethereum mainnet deployment.',
     subgraphId: 'JCNWRypm7FYwV8fx5HhzZPSFaMxgkPuw4TnR3Gpi81zk',
     schemaType: 'messari-lending',
     website: 'https://aave.com',
-    chains: ['Ethereum', 'Polygon', 'Avalanche', 'Arbitrum', 'Optimism'],
+    chains: ['Ethereum'],
     color: '#B6509E',
+  },
+  {
+    slug: 'aave-v3-arbitrum',
+    name: 'Aave V3 (Arbitrum)',
+    category: 'Lending',
+    description: 'Aave V3 on Arbitrum One. Major L2 lending venue with deep ARB ecosystem assets, separate liquidity from the Ethereum deployment.',
+    subgraphId: '4xyasjQeREe7PxnF6wVdobZvCw5mhoHZq3T7guRpuNPf',
+    schemaType: 'messari-lending',
+    website: 'https://app.aave.com',
+    chains: ['Arbitrum'],
+    color: '#28A0F0',
   },
   {
     slug: 'compound-v3',
@@ -46,6 +76,50 @@ export const PROTOCOLS: ProtocolConfig[] = [
     website: 'https://compound.finance',
     chains: ['Ethereum'],
     color: '#00D395',
+  },
+  {
+    slug: 'makerdao',
+    name: 'MakerDAO',
+    category: 'Lending',
+    description: 'Decentralised CDP-based lending protocol behind DAI, the longest-running on-chain stablecoin issuance system. Users lock collateral to mint DAI against it.',
+    subgraphId: '8sE6rTNkPhzZXZC6c8UQy2ghFTu5PPdGauwUBm4t7HZ1',
+    schemaType: 'messari-lending',
+    website: 'https://makerdao.com',
+    chains: ['Ethereum'],
+    color: '#1AAB9B',
+  },
+  {
+    slug: 'morpho-blue',
+    name: 'Morpho Blue',
+    category: 'Lending',
+    description: 'Permissionless lending primitive: each market is a single isolated pair of collateral and loan assets, with risk parameters set by curators rather than governance.',
+    subgraphId: '8Lz789DP5VKLXumTMTgygjU2xtuzx8AhbaacgN5PYCAs',
+    schemaType: 'messari-lending',
+    website: 'https://morpho.org',
+    chains: ['Ethereum'],
+    color: '#2470FF',
+  },
+  {
+    slug: 'spark-lend-gnosis',
+    name: 'Spark Lend (Gnosis)',
+    category: 'Lending',
+    description: 'Spark Lend on Gnosis Chain, the Aave V3 fork operated by the Sky / MakerDAO ecosystem and integrated with sDAI yield routing.',
+    subgraphId: 'Bw4RH37UbbGEhHo4FaWwT1dn9QJzm1XSZCyK1cbr6ZKM',
+    schemaType: 'messari-lending',
+    website: 'https://spark.fi',
+    chains: ['Gnosis'],
+    color: '#F58A65',
+  },
+  {
+    slug: 'lido',
+    name: 'Lido',
+    category: 'Liquid Staking',
+    description: 'Largest liquid staking protocol on Ethereum, issuing stETH against pooled validator stake and dominating the LST market.',
+    subgraphId: 'F7qb71hWab6SuRL5sf6LQLTpNahmqMsBnnweYHzLGUyG',
+    schemaType: 'messari-staking',
+    website: 'https://lido.fi',
+    chains: ['Ethereum'],
+    color: '#00A3FF',
   },
 ];
 

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -15,6 +15,7 @@ export interface ProtocolSummary {
   volume30dUSD: number;
   fees30dUSD: number;
   totalBorrowUSD?: number;
+  stakingAPR?: number;
 }
 
 export interface ProtocolDetail {
@@ -101,6 +102,47 @@ const MESSARI_LENDING_QUERY = `{
   }
 }`;
 
+// --- Messari Staking / Yield schema (used by the Messari Lido subgraph).
+//
+// Same `protocols` + `financialsDailySnapshots` shape as the other Messari templates,
+// but volume / fee semantics are different: dailySupplySideRevenueUSD is yield earned
+// by stakers and the protocol's cut is captured cumulatively but not split daily.
+//
+// Most Messari staking deployments (including Lido) write `dailyProtocolSideRevenueUSD = 0`
+// across every snapshot while still maintaining a non-zero `cumulativeProtocolSideRevenueUSD`.
+// To produce a usable daily-fees series we estimate it as a constant fraction of supply-side
+// revenue, derived from the protocol-level cumulative ratio.
+
+interface MessariStakingData {
+  protocols: Array<{
+    totalValueLockedUSD: string;
+    cumulativeSupplySideRevenueUSD: string;
+    cumulativeProtocolSideRevenueUSD: string;
+    cumulativeTotalRevenueUSD: string;
+  }>;
+  financialsDailySnapshots: Array<{
+    timestamp: string;
+    totalValueLockedUSD: string;
+    dailySupplySideRevenueUSD: string;
+    dailyProtocolSideRevenueUSD: string;
+  }>;
+}
+
+const MESSARI_STAKING_QUERY = `{
+  protocols(first: 1) {
+    totalValueLockedUSD
+    cumulativeSupplySideRevenueUSD
+    cumulativeProtocolSideRevenueUSD
+    cumulativeTotalRevenueUSD
+  }
+  financialsDailySnapshots(first: 90, orderBy: timestamp, orderDirection: desc) {
+    timestamp
+    totalValueLockedUSD
+    dailySupplySideRevenueUSD
+    dailyProtocolSideRevenueUSD
+  }
+}`;
+
 // --- Uniswap V3 native schema ---
 
 interface UniswapV3Data {
@@ -111,7 +153,7 @@ interface UniswapV3Data {
     txCount: string;
   }>;
   uniswapDayDatas: Array<{
-    date: string; // unix timestamp seconds (start of day)
+    date: string;
     volumeUSD: string;
     feesUSD: string;
     tvlUSD: string;
@@ -135,10 +177,6 @@ const UNISWAP_V3_QUERY = `{
 
 // --- Shared normalisation ---
 
-/**
- * Remove snapshots where feesUSD is an obvious outlier (>50× the median).
- * Some Messari subgraphs have single corrupt historical snapshots with absurd values.
- */
 function filterFeeOutliers(snapshots: ProtocolDaySnapshot[]): ProtocolDaySnapshot[] {
   if (snapshots.length < 3) return snapshots;
   const fees = snapshots.map((s) => s.feesUSD).sort((a, b) => a - b);
@@ -153,7 +191,7 @@ function computeSummary(
   cumulativeVolumeUSD: number,
   cumulativeFeesUSD: number,
   snapshots: ProtocolDaySnapshot[],
-  totalBorrowUSD?: number,
+  extras: Partial<ProtocolSummary> = {},
 ): ProtocolSummary {
   const thirtyDaysAgo = Date.now() / 1000 - 30 * 86400;
   const recent = snapshots.filter((s) => s.timestamp >= thirtyDaysAgo);
@@ -164,12 +202,26 @@ function computeSummary(
     cumulativeFeesUSD,
     volume30dUSD: recent.reduce((s, d) => s + d.volumeUSD, 0),
     fees30dUSD: recent.reduce((s, d) => s + d.feesUSD, 0),
-    totalBorrowUSD,
+    ...extras,
   };
 }
 
 function parseF(v: string | null | undefined): number {
   return parseFloat(v ?? '0') || 0;
+}
+
+// Some Messari subgraphs (Curve mainnet, certain Aave snapshots) leak unscaled
+// integer values into USD fields, producing impossible numbers like 3.7e20.
+// Anything north of $1 quadrillion (1e15) is a data-quality artefact, not a
+// real protocol metric. Clamp it to a snapshot-derived fallback so the UI
+// never renders "$ 376424613377.91B" and breaks card layout.
+const SANE_USD_CEILING = 1e15;
+
+function sanitizeCumulative(raw: number, snapshotSum: number): number {
+  if (!Number.isFinite(raw) || raw < 0 || raw > SANE_USD_CEILING) {
+    return Number.isFinite(snapshotSum) && snapshotSum >= 0 ? snapshotSum : 0;
+  }
+  return raw;
 }
 
 function normalizeMessariDex(slug: string, data: MessariDexData): ProtocolDetail {
@@ -184,12 +236,15 @@ function normalizeMessariDex(slug: string, data: MessariDexData): ProtocolDetail
     .sort((a, b) => a.timestamp - b.timestamp);
 
   const clean = filterFeeOutliers(snapshots);
+  const snapshotVolumeSum = clean.reduce((acc, s) => acc + s.volumeUSD, 0);
+  const snapshotFeesSum = clean.reduce((acc, s) => acc + s.feesUSD, 0);
+
   return {
     summary: computeSummary(
       slug,
       parseF(p?.totalValueLockedUSD),
-      parseF(p?.cumulativeVolumeUSD),
-      parseF(p?.cumulativeTotalRevenueUSD),
+      sanitizeCumulative(parseF(p?.cumulativeVolumeUSD), snapshotVolumeSum),
+      sanitizeCumulative(parseF(p?.cumulativeTotalRevenueUSD), snapshotFeesSum),
       clean,
     ),
     snapshots: clean,
@@ -208,14 +263,69 @@ function normalizeMessariLending(slug: string, data: MessariLendingData): Protoc
     .sort((a, b) => a.timestamp - b.timestamp);
 
   const clean = filterFeeOutliers(snapshots);
+  const snapshotVolumeSum = clean.reduce((acc, s) => acc + s.volumeUSD, 0);
+  const snapshotFeesSum = clean.reduce((acc, s) => acc + s.feesUSD, 0);
+
   return {
     summary: computeSummary(
       slug,
       parseF(p?.totalValueLockedUSD),
-      parseF(p?.cumulativeBorrowUSD),
-      parseF(p?.cumulativeTotalRevenueUSD),
+      sanitizeCumulative(parseF(p?.cumulativeBorrowUSD), snapshotVolumeSum),
+      sanitizeCumulative(parseF(p?.cumulativeTotalRevenueUSD), snapshotFeesSum),
       clean,
-      parseF(p?.totalBorrowBalanceUSD),
+      { totalBorrowUSD: parseF(p?.totalBorrowBalanceUSD) },
+    ),
+    snapshots: clean,
+  };
+}
+
+function normalizeMessariStaking(slug: string, data: MessariStakingData): ProtocolDetail {
+  const p = data.protocols[0];
+
+  // Estimate the daily fee from the cumulative protocol/supply-side ratio. Most
+  // staking deployments leave dailyProtocolSideRevenueUSD at 0 even though the
+  // cumulative is correct, so we back-derive it for a continuous fees chart.
+  const cumulativeSupply = parseF(p?.cumulativeSupplySideRevenueUSD);
+  const cumulativeProtocol = parseF(p?.cumulativeProtocolSideRevenueUSD);
+  const protocolFeeRatio = cumulativeSupply > 0
+    ? cumulativeProtocol / cumulativeSupply
+    : 0;
+
+  const snapshots: ProtocolDaySnapshot[] = data.financialsDailySnapshots
+    .map((s) => {
+      const supply = parseF(s.dailySupplySideRevenueUSD);
+      const reportedProtocol = parseF(s.dailyProtocolSideRevenueUSD);
+      // Use the reported daily fee if present, else estimate from the ratio.
+      const fees = reportedProtocol > 0 ? reportedProtocol : supply * protocolFeeRatio;
+      return {
+        timestamp: parseInt(s.timestamp),
+        tvlUSD: parseF(s.totalValueLockedUSD),
+        volumeUSD: supply,
+        feesUSD: fees,
+      };
+    })
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const clean = filterFeeOutliers(snapshots);
+  const snapshotVolumeSum = clean.reduce((acc, s) => acc + s.volumeUSD, 0);
+  const snapshotFeesSum = clean.reduce((acc, s) => acc + s.feesUSD, 0);
+
+  // Estimate APR from the most recent 30 days of supply-side revenue vs current TVL.
+  const tvl = parseF(p?.totalValueLockedUSD);
+  const last30 = clean.slice(-30);
+  const last30Yield = last30.reduce((sum, d) => sum + d.volumeUSD, 0);
+  const stakingAPR = tvl > 0 && last30.length > 0
+    ? (last30Yield / tvl) * (365 / last30.length) * 100
+    : 0;
+
+  return {
+    summary: computeSummary(
+      slug,
+      tvl,
+      sanitizeCumulative(cumulativeSupply, snapshotVolumeSum),
+      sanitizeCumulative(cumulativeProtocol, snapshotFeesSum),
+      clean,
+      { stakingAPR },
     ),
     snapshots: clean,
   };
@@ -256,6 +366,10 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
     case 'messari-lending': {
       const data = await queryProtocolSubgraph<MessariLendingData>(config.subgraphId, MESSARI_LENDING_QUERY);
       return normalizeMessariLending(config.slug, data);
+    }
+    case 'messari-staking': {
+      const data = await queryProtocolSubgraph<MessariStakingData>(config.subgraphId, MESSARI_STAKING_QUERY);
+      return normalizeMessariStaking(config.slug, data);
     }
     case 'uniswap-v3': {
       const data = await queryProtocolSubgraph<UniswapV3Data>(config.subgraphId, UNISWAP_V3_QUERY);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -75,6 +75,9 @@ export function formatPercent(value: number, decimals = 2): string {
  * Format USD currency with compact notation for large values
  */
 export function formatUSD(amount: number, decimals = 2): string {
+  if (decimals <= 2 && amount >= 1e12) {
+    return `$ ${(amount / 1e12).toFixed(2)}T`;
+  }
   if (decimals <= 2 && amount >= 1e9) {
     return `$ ${(amount / 1e9).toFixed(2)}B`;
   }


### PR DESCRIPTION
## Summary

Expands `/protocols` from 3 to 9 protocols across 3 categories using only The Graph's product suite. New: Uniswap V3 Polygon, Aave V3 Arbitrum, Compound V3, MakerDAO, Morpho Blue, Spark Lend Gnosis, Lido.

Adds a new `messari-staking` schema variant with a proportional-fee derivation path so liquid-staking protocols render meaningful 30d / 90d fee charts even when daily protocol-revenue snapshots are zeroed.

## What changed

- `src/lib/protocols/config.ts` — adds `messari-staking` schema, `Liquid Staking` category, 6 new `ProtocolConfig` entries.
- `src/lib/protocols/fetcher.ts` — `messari-staking` handler with proportional fee back-derivation (cumulative protocol-side / cumulative supply-side ratio), plus a `sanitizeCumulative` helper that clamps obviously inflated cumulative values (>1e15) against the snapshot-derived sum.
- `src/app/protocols/page.tsx` — Liquid Staking category style; `whitespace-nowrap` on numeric cells so multi-trillion TVL stays inside its column.
- `src/app/protocols/[slug]/page.tsx` — staking-specific tile labels (Total Value Staked, 30d Staker Yield, Daily Yield to Stakers) plus a 30d-estimated APR tile.
- `src/lib/utils.ts` — trillion (`T`) compact notation in `formatUSD`.
- `RFC-003-PROTOCOL-EXPANSION.md` (new) — full methodology, MCP-driven discovery process, and 10 documented Graph platform gaps with unblocking suggestions.

## Discovery methodology

Used the Graph subgraph MCP servers (`graph-lending`, `graph-uniswap`, `graph-aave`, `graph-lido`) as the discovery layer rather than Explorer search. Documented in the RFC alongside specific platform gaps where MCP responses don't currently expose `subgraphId`, which would unblock more aggressive expansion. Several Messari subgraphs surfaced via Explorer turned out to be stale or write zeroed data, so the MCP-led path produced a higher hit rate of working sources.

## Known data quality issue: Morpho Blue fees

The Messari morpho-blue subgraph (`8Lz789DP5VKLXumTMTgygjU2xtuzx8AhbaacgN5PYCAs`) writes `0` to `dailyProtocolSideRevenueUSD` across all `financialsDailySnapshots` even though `cumulativeProtocolSideRevenueUSD` shows non-trivial values. Result: Morpho's 30d Fees tile reads `$0` and the Daily Fees panel renders empty. Other panels (TVL, Active Borrows, Daily Borrowing) render correctly.

This is an upstream subgraph issue, not a Lodestar bug. Three reasonable directions, deferring to your call:

1. **Merge as-is** and let the empty fee panel itself signal the gap to users.
2. **Drop Morpho** from this PR until a fixed subgraph is available.
3. **Hide the fee panel** for any protocol where 30d fees == 0 (would also affect spark-lend-gnosis edge cases).

Happy to take any of those directions if you want a follow-up commit.

## Test plan

- [ ] `/protocols` renders 9-row directory; TVL, 30d Volume, 30d Fees columns all populated except where data is genuinely missing
- [ ] Each detail page renders without console errors
- [ ] Lido detail page shows 5 tiles (incl. APR) and 3 charts
- [ ] Morpho fee panel shows expected empty state (see above)
- [ ] No regression on existing Uniswap V3, Aave V3, Compound V3 pages
- [ ] `pnpm lint` and `pnpm type-check` clean on changed files