### PR TITLE
feat(protocols): add Yield Aggregator category and Yearn V2

### DIFF
--- a/src/app/protocols/[slug]/page.tsx
+++ b/src/app/protocols/[slug]/page.tsx
@@ -93,6 +93,16 @@ const CATEGORY_LABELS: Record<ProtocolCategory, CategoryLabels> = {
     cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
     cumulativeSub: 'all time',
   },
+  'Yield Aggregator': {
+    tvlLabel: 'Total Value Locked',
+    volumeLabel: '30d Yield to Depositors',
+    volumeChartTitle: 'Daily Yield (90 days)',
+    volumeTooltipLabel: 'Yield',
+    feesLabel: '30d Protocol Fees',
+    cumulativeLabel: 'Cumulative Yield',
+    cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
+    cumulativeSub: 'all time',
+  },
 };
 
 interface ExtraStat {
@@ -104,6 +114,9 @@ function getExtraStats(category: ProtocolCategory, summary?: ProtocolSummary): E
   if (!summary) return [];
   if (category === 'Liquid Staking' && summary.stakingAPR) {
     return [{ label: 'Staking APR (30d est.)', value: formatPercent(summary.stakingAPR) }];
+  }
+  if (category === 'Yield Aggregator' && summary.stakingAPR) {
+    return [{ label: 'Net APY (30d est.)', value: formatPercent(summary.stakingAPR) }];
   }
   return [];
 }

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -10,6 +10,7 @@ const CATEGORY_STYLES: Record<string, string> = {
   'DEX': 'bg-[var(--accent)]/10 text-[var(--accent)]',
   'Lending': 'bg-[var(--green)]/10 text-[var(--green)]',
   'Liquid Staking': 'bg-[#00A3FF]/12 text-[#5BC2FF]',
+  'Yield Aggregator': 'bg-[#0657F9]/12 text-[#6E92FF]',
 };
 
 function CategoryBadge({ category }: { category: string }) {

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -2,13 +2,15 @@ export type SchemaType =
   | 'messari-dex'
   | 'messari-lending'
   | 'messari-staking'
+  | 'messari-yield'
   | 'uniswap-v3'
   | 'etherfi-native';
 
 export type ProtocolCategory =
   | 'DEX'
   | 'Lending'
-  | 'Liquid Staking';
+  | 'Liquid Staking'
+  | 'Yield Aggregator';
 
 export interface ProtocolConfig {
   slug: string;
@@ -135,6 +137,17 @@ export const PROTOCOLS: ProtocolConfig[] = [
     website: 'https://ether.fi',
     chains: ['Ethereum'],
     color: '#A0FFE6',
+  },
+  {
+    slug: 'yearn-v2',
+    name: 'Yearn V2',
+    category: 'Yield Aggregator',
+    description: 'Long-running yield optimisation protocol that routes deposits across vault strategies to maximise returns. The Ethereum mainnet V2 deployment, original automated yield primitive in DeFi.',
+    subgraphId: 'FDLuaz69DbMADuBjJDEcLnTuPnjhZqNbFVrkNiBLGkEg',
+    schemaType: 'messari-yield',
+    website: 'https://yearn.fi',
+    chains: ['Ethereum'],
+    color: '#0657F9',
   },
 ];
 

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -2,7 +2,8 @@ export type SchemaType =
   | 'messari-dex'
   | 'messari-lending'
   | 'messari-staking'
-  | 'uniswap-v3';
+  | 'uniswap-v3'
+  | 'etherfi-native';
 
 export type ProtocolCategory =
   | 'DEX'
@@ -123,6 +124,17 @@ export const PROTOCOLS: ProtocolConfig[] = [
     website: 'https://lido.fi',
     chains: ['Ethereum'],
     color: '#00A3FF',
+  },
+  {
+    slug: 'ether-fi',
+    name: 'ether.fi',
+    category: 'Liquid Staking',
+    description: 'Liquid restaking protocol on Ethereum issuing eETH (rebasing) and weETH (wrapped). Stakers earn validator rewards plus EigenLayer restaking yield. Largest LRT by TVL.',
+    subgraphId: 'AEsX7AeqTD9bpFFaHwmCZbEXaHWsmzekoPKKuJUGQiQA',
+    schemaType: 'etherfi-native',
+    website: 'https://ether.fi',
+    chains: ['Ethereum'],
+    color: '#A0FFE6',
   },
 ];
 

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -175,6 +175,62 @@ const UNISWAP_V3_QUERY = `{
   }
 }`;
 
+// --- EtherFi native schema ---
+//
+// ether.fi's v3 subgraph stores values in ETH (BigInt wei) and exposes a
+// stream of `rebaseEvents` carrying the post-rebase totalEthLocked and
+// totalEEthShares. To produce the same TVL/Volume/Fees/APR shape as the
+// other Liquid Staking protocols we:
+//
+//   1. Fetch all rebases in the last ~95 days (5 events/day average).
+//   2. Group by day, take the last event of each day.
+//   3. Derive net yield-to-stakers via the eETH share-price delta:
+//        priceUSD(day) = totalEthLocked(day) / totalEEthShares(day)
+//        yieldEth(day) = sharesPrev * (priceUSD(day) - priceUSD(day-1))
+//      This isolates rebase yield from deposits and withdrawals, since
+//      share price only moves with rebases (deposits mint at par).
+//   4. Multiply by current ETH/USD (fetched in parallel from Uniswap V3
+//      mainnet) for USD denomination. Historic rebases are anchored to
+//      today's ETH price, an acceptable approximation given Lodestar's
+//      'current snapshot' framing.
+//   5. Approximate protocol fees as 10% of supply-side yield, matching
+//      ether.fi's documented protocol take. Replace with a real source
+//      if/when the subgraph exposes it.
+
+const ETHERFI_PROTOCOL_FEE_RATIO = 0.10;
+// ETH mainnet Uniswap V3 subgraph (already used elsewhere in lodestar) —
+// queried only for `bundle.ethPriceUSD` to convert ETH-denominated values.
+const UNISWAP_V3_ETH_MAINNET_SUBGRAPH = '5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV';
+
+interface EtherFiData {
+  rebaseEvents: Array<{
+    timestamp: string;
+    totalEthLocked: string;
+    totalEEthShares: string;
+    aprs: string[];
+  }>;
+}
+
+interface EthPriceData {
+  bundles: Array<{ ethPriceUSD: string }>;
+}
+
+const ETHERFI_QUERY = `{
+  rebaseEvents(
+    first: 1000
+    orderBy: timestamp
+    orderDirection: desc
+    where: { timestamp_gt: "$SINCE" }
+  ) {
+    timestamp
+    totalEthLocked
+    totalEEthShares
+    aprs
+  }
+}`;
+
+const ETH_PRICE_QUERY = `{ bundles(first: 1) { ethPriceUSD } }`;
+
 // --- Shared normalisation ---
 
 function filterFeeOutliers(snapshots: ProtocolDaySnapshot[]): ProtocolDaySnapshot[] {
@@ -331,6 +387,70 @@ function normalizeMessariStaking(slug: string, data: MessariStakingData): Protoc
   };
 }
 
+function normalizeEtherFi(
+  slug: string,
+  rebases: EtherFiData['rebaseEvents'],
+  ethPriceUSD: number,
+): ProtocolDetail {
+  if (rebases.length === 0 || ethPriceUSD <= 0) {
+    return {
+      summary: computeSummary(slug, 0, 0, 0, []),
+      snapshots: [],
+    };
+  }
+
+  // Group rebases by UTC day, keeping the last event of each day.
+  const byDay = new Map<number, EtherFiData['rebaseEvents'][number]>();
+  for (const r of rebases) {
+    const day = Math.floor(parseInt(r.timestamp) / 86400);
+    const existing = byDay.get(day);
+    if (!existing || parseInt(r.timestamp) > parseInt(existing.timestamp)) {
+      byDay.set(day, r);
+    }
+  }
+  const sorted = Array.from(byDay.values()).sort(
+    (a, b) => parseInt(a.timestamp) - parseInt(b.timestamp),
+  );
+
+  const latest = sorted[sorted.length - 1];
+  const tvlUSD = (parseFloat(latest.totalEthLocked) / 1e18) * ethPriceUSD;
+
+  const snapshots: ProtocolDaySnapshot[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const curr = sorted[i];
+    const sharesPrev = parseFloat(prev.totalEEthShares) / 1e18;
+    const sharesCurr = parseFloat(curr.totalEEthShares) / 1e18;
+    const ethPrev = parseFloat(prev.totalEthLocked) / 1e18;
+    const ethCurr = parseFloat(curr.totalEthLocked) / 1e18;
+    const pricePrev = sharesPrev > 0 ? ethPrev / sharesPrev : 1;
+    const priceCurr = sharesCurr > 0 ? ethCurr / sharesCurr : 1;
+    const yieldEth = Math.max(0, sharesPrev * (priceCurr - pricePrev));
+    const yieldUSD = yieldEth * ethPriceUSD;
+    snapshots.push({
+      timestamp: parseInt(curr.timestamp),
+      tvlUSD: ethCurr * ethPriceUSD,
+      volumeUSD: yieldUSD,
+      feesUSD: yieldUSD * ETHERFI_PROTOCOL_FEE_RATIO,
+    });
+  }
+
+  const clean = filterFeeOutliers(snapshots);
+  const cumulativeYield = clean.reduce((sum, s) => sum + s.volumeUSD, 0);
+  const cumulativeFees = clean.reduce((sum, s) => sum + s.feesUSD, 0);
+
+  const last30 = clean.slice(-30);
+  const last30Yield = last30.reduce((sum, s) => sum + s.volumeUSD, 0);
+  const stakingAPR = tvlUSD > 0 && last30.length > 0
+    ? (last30Yield / tvlUSD) * (365 / last30.length) * 100
+    : 0;
+
+  return {
+    summary: computeSummary(slug, tvlUSD, cumulativeYield, cumulativeFees, clean, { stakingAPR }),
+    snapshots: clean,
+  };
+}
+
 function normalizeUniswapV3(slug: string, data: UniswapV3Data): ProtocolDetail {
   const f = data.factories[0];
   const snapshots: ProtocolDaySnapshot[] = data.uniswapDayDatas
@@ -374,6 +494,16 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
     case 'uniswap-v3': {
       const data = await queryProtocolSubgraph<UniswapV3Data>(config.subgraphId, UNISWAP_V3_QUERY);
       return normalizeUniswapV3(config.slug, data);
+    }
+    case 'etherfi-native': {
+      const since = Math.floor(Date.now() / 1000) - 95 * 86400;
+      const query = ETHERFI_QUERY.replace('$SINCE', String(since));
+      const [rebases, price] = await Promise.all([
+        queryProtocolSubgraph<EtherFiData>(config.subgraphId, query),
+        queryProtocolSubgraph<EthPriceData>(UNISWAP_V3_ETH_MAINNET_SUBGRAPH, ETH_PRICE_QUERY),
+      ]);
+      const ethPriceUSD = parseF(price.bundles[0]?.ethPriceUSD);
+      return normalizeEtherFi(config.slug, rebases.rebaseEvents, ethPriceUSD);
     }
   }
 }

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -143,6 +143,42 @@ const MESSARI_STAKING_QUERY = `{
   }
 }`;
 
+// --- Messari Yield Aggregator schema (used by Yearn V2 Ethereum and similar).
+//
+// Mirrors the Messari Staking shape: same field names, same dailyProtocolSide=0
+// quirk, same proportional fee back-derivation. The only difference is the
+// protocol-level entity is `yieldAggregators` instead of `protocols`.
+
+interface MessariYieldData {
+  yieldAggregators: Array<{
+    totalValueLockedUSD: string;
+    cumulativeSupplySideRevenueUSD: string;
+    cumulativeProtocolSideRevenueUSD: string;
+    cumulativeTotalRevenueUSD: string;
+  }>;
+  financialsDailySnapshots: Array<{
+    timestamp: string;
+    totalValueLockedUSD: string;
+    dailySupplySideRevenueUSD: string;
+    dailyProtocolSideRevenueUSD: string;
+  }>;
+}
+
+const MESSARI_YIELD_QUERY = `{
+  yieldAggregators(first: 1) {
+    totalValueLockedUSD
+    cumulativeSupplySideRevenueUSD
+    cumulativeProtocolSideRevenueUSD
+    cumulativeTotalRevenueUSD
+  }
+  financialsDailySnapshots(first: 90, orderBy: timestamp, orderDirection: desc) {
+    timestamp
+    totalValueLockedUSD
+    dailySupplySideRevenueUSD
+    dailyProtocolSideRevenueUSD
+  }
+}`;
+
 // --- Uniswap V3 native schema ---
 
 interface UniswapV3Data {
@@ -387,6 +423,57 @@ function normalizeMessariStaking(slug: string, data: MessariStakingData): Protoc
   };
 }
 
+function normalizeMessariYield(slug: string, data: MessariYieldData): ProtocolDetail {
+  // Same back-derivation pattern as normalizeMessariStaking: yield-aggregator
+  // subgraphs leave dailyProtocolSideRevenueUSD at 0 in snapshots while the
+  // cumulative figure is correct. We back-derive a daily protocol fee using
+  // the cumulative protocol/supply ratio so the fees chart renders.
+  const p = data.yieldAggregators[0];
+  const cumulativeSupply = parseF(p?.cumulativeSupplySideRevenueUSD);
+  const cumulativeProtocol = parseF(p?.cumulativeProtocolSideRevenueUSD);
+  const protocolFeeRatio = cumulativeSupply > 0
+    ? cumulativeProtocol / cumulativeSupply
+    : 0;
+
+  const snapshots: ProtocolDaySnapshot[] = data.financialsDailySnapshots
+    .map((s) => {
+      const supply = parseF(s.dailySupplySideRevenueUSD);
+      const reportedProtocol = parseF(s.dailyProtocolSideRevenueUSD);
+      const fees = reportedProtocol > 0 ? reportedProtocol : supply * protocolFeeRatio;
+      return {
+        timestamp: parseInt(s.timestamp),
+        tvlUSD: parseF(s.totalValueLockedUSD),
+        volumeUSD: supply,
+        feesUSD: fees,
+      };
+    })
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const clean = filterFeeOutliers(snapshots);
+  const snapshotVolumeSum = clean.reduce((acc, s) => acc + s.volumeUSD, 0);
+  const snapshotFeesSum = clean.reduce((acc, s) => acc + s.feesUSD, 0);
+
+  // 30d-window APY estimate, identical formula to Liquid Staking.
+  const tvl = parseF(p?.totalValueLockedUSD);
+  const last30 = clean.slice(-30);
+  const last30Yield = last30.reduce((sum, d) => sum + d.volumeUSD, 0);
+  const stakingAPR = tvl > 0 && last30.length > 0
+    ? (last30Yield / tvl) * (365 / last30.length) * 100
+    : 0;
+
+  return {
+    summary: computeSummary(
+      slug,
+      tvl,
+      sanitizeCumulative(cumulativeSupply, snapshotVolumeSum),
+      sanitizeCumulative(cumulativeProtocol, snapshotFeesSum),
+      clean,
+      { stakingAPR },
+    ),
+    snapshots: clean,
+  };
+}
+
 function normalizeEtherFi(
   slug: string,
   rebases: EtherFiData['rebaseEvents'],
@@ -490,6 +577,10 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
     case 'messari-staking': {
       const data = await queryProtocolSubgraph<MessariStakingData>(config.subgraphId, MESSARI_STAKING_QUERY);
       return normalizeMessariStaking(config.slug, data);
+    }
+    case 'messari-yield': {
+      const data = await queryProtocolSubgraph<MessariYieldData>(config.subgraphId, MESSARI_YIELD_QUERY);
+      return normalizeMessariYield(config.slug, data);
     }
     case 'uniswap-v3': {
       const data = await queryProtocolSubgraph<UniswapV3Data>(config.subgraphId, UNISWAP_V3_QUERY);


### PR DESCRIPTION
## Summary

Adds a new \"Yield Aggregator\" `ProtocolCategory` and Yearn V2 as the first protocol in it. The directory now spans four categories (DEX, Lending, Liquid Staking, Yield Aggregator) and 11 protocols.

## What changed

- New `ProtocolCategory: 'Yield Aggregator'` with directory badge styling and detail-page tile labels (Total Value Locked / 30d Yield to Depositors / 30d Protocol Fees / Cumulative Yield, plus a Net APY (30d est.) extra tile).
- New `SchemaType: 'messari-yield'` adapter for the Messari yield-aggregator template. It mirrors the existing `messari-staking` shape, just keyed off the `yieldAggregators` entity instead of `protocols`.
- Same proportional-fee back-derivation as Liquid Staking, since `dailyProtocolSideRevenueUSD` is `0` in snapshots while the cumulative figure is correct (~14.9% protocol fee ratio for Yearn V2 on mainnet).
- Yearn V2 (Ethereum) added: subgraph `FDLuaz69DbMADuBjJDEcLnTuPnjhZqNbFVrkNiBLGkEg`.

## Live data

| Metric                | Value     |
| --------------------- | --------- |
| Total Value Locked    | \$55.99M  |
| 30d Yield to Depositors | \$235.04K |
| 30d Protocol Fees     | \$32.65K  |
| Cumulative Yield (all time) | \$275.45M |
| Net APY (30d est)     | 4.98%     |

## Stacking note

This branch is stacked on top of #3 (ether.fi addition). The first commit in this PR is the same ether.fi commit as #3. If you merge #3 first, this PR will auto-rebase to a single commit. If you'd prefer this as a self-contained PR (one commit, no #3 dependency) I can rebase off main directly once #3 lands.

## Test plan

- [ ] `/protocols` directory shows Yearn V2 at row 11 with the Yield Aggregator badge and populated TVL / 30d Volume / 30d Fees
- [ ] `/protocols/yearn-v2` detail page renders all four KPI tiles, the Net APY tile, and three populated charts
- [ ] No regression on existing protocol pages
- [ ] `pnpm lint` and `pnpm type-check` clean on changed files