### PR TITLE
feat(protocols): expand directory to 23 protocols, 6 categories

### DIFF
--- a/src/app/api/protocols/route.ts
+++ b/src/app/api/protocols/route.ts
@@ -1,11 +1,20 @@
 import { NextResponse } from 'next/server';
+import { createHash } from 'node:crypto';
 import { cached } from '@/lib/cache';
 import { PROTOCOLS } from '@/lib/protocols/config';
 import { fetchProtocolSummary } from '@/lib/protocols/fetcher';
 
+// Hash the slug list into the cache key so adding, removing, or reordering
+// protocols invalidates the cached directory automatically. Otherwise the
+// cached array gets re-served by index against a different PROTOCOLS shape.
+const directoryCacheKey = `lodestar:protocols:directory:${createHash('sha1')
+  .update(PROTOCOLS.map((p) => p.slug).join(','))
+  .digest('hex')
+  .slice(0, 8)}`;
+
 export async function GET() {
   try {
-    const summaries = await cached('lodestar:protocols:directory', 3600, () =>
+    const summaries = await cached(directoryCacheKey, 3600, () =>
       Promise.all(PROTOCOLS.map((p) => fetchProtocolSummary(p)))
     );
 

--- a/src/app/protocols/[slug]/page.tsx
+++ b/src/app/protocols/[slug]/page.tsx
@@ -93,6 +93,16 @@ const CATEGORY_LABELS: Record<ProtocolCategory, CategoryLabels> = {
     cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
     cumulativeSub: 'all time',
   },
+  'Yield Aggregator': {
+    tvlLabel: 'Total Value Locked',
+    volumeLabel: '30d Yield to Depositors',
+    volumeChartTitle: 'Daily Yield (90 days)',
+    volumeTooltipLabel: 'Yield',
+    feesLabel: '30d Protocol Fees',
+    cumulativeLabel: 'Cumulative Yield',
+    cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
+    cumulativeSub: 'all time',
+  },
 };
 
 interface ExtraStat {
@@ -104,6 +114,9 @@ function getExtraStats(category: ProtocolCategory, summary?: ProtocolSummary): E
   if (!summary) return [];
   if (category === 'Liquid Staking' && summary.stakingAPR) {
     return [{ label: 'Staking APR (30d est.)', value: formatPercent(summary.stakingAPR) }];
+  }
+  if (category === 'Yield Aggregator' && summary.stakingAPR) {
+    return [{ label: 'Net APY (30d est.)', value: formatPercent(summary.stakingAPR) }];
   }
   return [];
 }

--- a/src/app/protocols/[slug]/page.tsx
+++ b/src/app/protocols/[slug]/page.tsx
@@ -129,6 +129,16 @@ const CATEGORY_LABELS: Record<ProtocolCategory, CategoryLabels> = {
     cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
     cumulativeSub: 'all time',
   },
+  'Bridge': {
+    tvlLabel: 'Total Value Locked',
+    volumeLabel: '30d Bridged Out',
+    volumeChartTitle: 'Daily Bridge Volume (90 days)',
+    volumeTooltipLabel: 'Bridged Out',
+    feesLabel: '30d Fees',
+    cumulativeLabel: 'Cumulative Volume',
+    cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
+    cumulativeSub: 'all time',
+  },
 };
 
 interface ExtraStat {
@@ -240,7 +250,7 @@ function PredictionMarketsView({
           { label: 'Active Markets', value: placeholder ? '—' : formatCount(detail.activeMarkets) },
           { label: 'Resolved Markets', value: placeholder ? '—' : formatCount(detail.resolvedMarkets) },
           { label: 'Unique Traders', value: placeholder ? '—' : formatCount(detail.totalTraders) },
-          { label: 'Disputed Resolutions', value: placeholder ? '—' : formatCount(detail.disputedCount), sub: detail && detail.disputedCount >= 1000 ? '1000+ tracked' : undefined },
+          { label: 'Disputed Resolutions', value: placeholder ? '—' : formatCount(detail.disputedCount), sub: detail && detail.disputedCount >= 250 ? '250+ tracked' : undefined },
         ].map((s) => (
           <div key={s.label} className="p-3 rounded-[var(--radius-button)] bg-[var(--bg-elevated)]/60 border border-[var(--border)]">
             <p className="text-[10px] text-[var(--text-faint)] mb-0.5">{s.label}</p>
@@ -327,27 +337,49 @@ function PredictionMarketsView({
                 <thead>
                   <tr className="border-b border-[var(--border)]">
                     <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)] w-8">#</th>
-                    <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">Condition ID</th>
+                    <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">Market</th>
                     <th className="text-right py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">OI</th>
                     <th className="text-right py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">Splits</th>
                     <th className="text-right py-2 text-[11px] font-medium text-[var(--text-faint)]">Merges</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {detail.topMarketsByOI.map((m, i) => (
-                    <tr
-                      key={m.id}
-                      className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-elevated)]/40 transition-colors"
-                    >
-                      <td className="py-2.5 pr-4 text-[var(--text-faint)] font-mono text-xs">{i + 1}</td>
-                      <td className="py-2.5 pr-4 text-[var(--text-muted)] font-mono text-xs">
-                        {m.id.slice(0, 10)}…{m.id.slice(-6)}
-                      </td>
-                      <td className="py-2.5 pr-4 text-right font-mono text-[var(--text)] whitespace-nowrap">{formatUSD(m.amountUSD)}</td>
-                      <td className="py-2.5 pr-4 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap">{formatCount(m.splitCount)}</td>
-                      <td className="py-2.5 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap">{formatCount(m.mergeCount)}</td>
-                    </tr>
-                  ))}
+                  {detail.topMarketsByOI.map((m, i) => {
+                    const idShort = `${m.id.slice(0, 10)}…${m.id.slice(-6)}`;
+                    const titleNode = m.title ? (
+                      m.slug ? (
+                        <a
+                          href={`https://polymarket.com/event/${m.slug}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[var(--text)] hover:text-[var(--accent)] transition-colors line-clamp-2 leading-snug"
+                        >
+                          {m.title}
+                        </a>
+                      ) : (
+                        <span className="text-[var(--text)] line-clamp-2 leading-snug">{m.title}</span>
+                      )
+                    ) : (
+                      <span className="text-[var(--text-muted)] font-mono text-xs">{idShort}</span>
+                    );
+                    return (
+                      <tr
+                        key={m.id}
+                        className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-elevated)]/40 transition-colors"
+                      >
+                        <td className="py-2.5 pr-4 text-[var(--text-faint)] font-mono text-xs align-top">{i + 1}</td>
+                        <td className="py-2.5 pr-4 max-w-md align-top">
+                          {titleNode}
+                          {m.title && (
+                            <div className="text-[10px] text-[var(--text-faint)] font-mono mt-0.5">{idShort}</div>
+                          )}
+                        </td>
+                        <td className="py-2.5 pr-4 text-right font-mono text-[var(--text)] whitespace-nowrap align-top">{formatUSD(m.amountUSD)}</td>
+                        <td className="py-2.5 pr-4 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap align-top">{formatCount(m.splitCount)}</td>
+                        <td className="py-2.5 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap align-top">{formatCount(m.mergeCount)}</td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
@@ -402,6 +434,11 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
   // (e.g. Polymarket's orderbook). When that's the case, normalize() returns
   // an empty snapshots array and the TVL/Volume charts have nothing to draw.
   const hasDailySeries = !isLoading && chartData.length > 0;
+  // Route the knownIssues notice to the chart it actually affects. Defaults to
+  // 'fees' to preserve existing behavior for Morpho Blue.
+  const issueAffects = config.knownIssueAffects ?? 'fees';
+  const volumeIssue = config.knownIssues && issueAffects === 'volume' ? config.knownIssues : null;
+  const feesIssue = config.knownIssues && issueAffects === 'fees' ? config.knownIssues : null;
 
   // Lending uses Active Borrows (current snapshot) instead of summed 30d volume
   const volumeKpiValue = config.category === 'Lending'
@@ -546,6 +583,11 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
           <CardContent>
             {isLoading ? (
               <ChartSkeleton height="180px" />
+            ) : volumeIssue ? (
+              <div className="h-[180px] flex flex-col items-center justify-center gap-2 text-center px-4">
+                <p className="text-[11px] font-medium text-[var(--yellow,#f59e0b)]">Upstream data issue</p>
+                <p className="text-[11px] text-[var(--text-muted)] max-w-xs">{volumeIssue}</p>
+              </div>
             ) : !hasDailySeries ? (
               <div className="h-[180px] flex flex-col items-center justify-center gap-2 text-center px-4">
                 <p className="text-[11px] font-medium text-[var(--text-muted)]">No daily series available</p>
@@ -589,10 +631,10 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
           <CardContent>
             {isLoading ? (
               <ChartSkeleton height="180px" />
-            ) : config.knownIssues ? (
+            ) : feesIssue ? (
               <div className="h-[180px] flex flex-col items-center justify-center gap-2 text-center px-4">
                 <p className="text-[11px] font-medium text-[var(--yellow,#f59e0b)]">Upstream data issue</p>
-                <p className="text-[11px] text-[var(--text-muted)] max-w-xs">{config.knownIssues}</p>
+                <p className="text-[11px] text-[var(--text-muted)] max-w-xs">{feesIssue}</p>
               </div>
             ) : (
               <div className="h-[180px]">

--- a/src/app/protocols/[slug]/page.tsx
+++ b/src/app/protocols/[slug]/page.tsx
@@ -103,6 +103,16 @@ const CATEGORY_LABELS: Record<ProtocolCategory, CategoryLabels> = {
     cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
     cumulativeSub: 'all time',
   },
+  'Prediction Markets': {
+    tvlLabel: 'Open Interest',
+    volumeLabel: '30d Volume',
+    volumeChartTitle: 'Daily Volume (90 days)',
+    volumeTooltipLabel: 'Volume',
+    feesLabel: '30d Fees',
+    cumulativeLabel: 'Lifetime Volume',
+    cumulativeValue: (s) => s?.cumulativeVolumeUSD ?? 0,
+    cumulativeSub: 'all time',
+  },
 };
 
 interface ExtraStat {
@@ -139,6 +149,10 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
 
   const labels = CATEGORY_LABELS[config.category];
   const extras = getExtraStats(config.category, summary);
+  // Some protocols don't expose a daily aggregate entity in their subgraphs
+  // (e.g. Polymarket's orderbook). When that's the case, normalize() returns
+  // an empty snapshots array and the TVL/Volume charts have nothing to draw.
+  const hasDailySeries = !isLoading && chartData.length > 0;
 
   // Lending uses Active Borrows (current snapshot) instead of summed 30d volume
   const volumeKpiValue = config.category === 'Lending'
@@ -225,6 +239,11 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
         <CardContent>
           {isLoading ? (
             <ChartSkeleton height="220px" />
+          ) : !hasDailySeries ? (
+            <div className="h-[220px] flex flex-col items-center justify-center gap-2 text-center px-4">
+              <p className="text-[11px] font-medium text-[var(--text-muted)]">No daily series available</p>
+              <p className="text-[11px] text-[var(--text-faint)] max-w-md">Headline numbers above are computed from cumulative on-chain state. The upstream subgraph does not expose a daily aggregate entity, so a 90-day TVL chart is not available for this protocol.</p>
+            </div>
           ) : (
             <div className="h-[220px]">
               <ResponsiveContainer width="100%" height="100%">
@@ -278,6 +297,11 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
           <CardContent>
             {isLoading ? (
               <ChartSkeleton height="180px" />
+            ) : !hasDailySeries ? (
+              <div className="h-[180px] flex flex-col items-center justify-center gap-2 text-center px-4">
+                <p className="text-[11px] font-medium text-[var(--text-muted)]">No daily series available</p>
+                <p className="text-[11px] text-[var(--text-faint)] max-w-xs">{labels.cumulativeLabel} is shown above as a lifetime total.</p>
+              </div>
             ) : (
               <div className="h-[180px]">
                 <ResponsiveContainer width="100%" height="100%">

--- a/src/app/protocols/[slug]/page.tsx
+++ b/src/app/protocols/[slug]/page.tsx
@@ -14,8 +14,8 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { getProtocol, type ProtocolCategory } from '@/lib/protocols/config';
-import type { ProtocolSummary } from '@/lib/protocols/fetcher';
+import { getProtocol, type ProtocolCategory, type ProtocolConfig } from '@/lib/protocols/config';
+import type { PredictionMarketsDetail, ProtocolSummary } from '@/lib/protocols/fetcher';
 import { useProtocolDetail } from '@/hooks/useProtocols';
 import { formatUSD } from '@/lib/utils';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
@@ -39,6 +39,22 @@ function formatDate(timestamp: number) {
 
 function formatPercent(n: number) {
   return `${n.toFixed(2)}%`;
+}
+
+function formatCount(n: number) {
+  if (n >= 1e9) return `${(n / 1e9).toFixed(2)}B`;
+  if (n >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(1)}K`;
+  return n.toLocaleString('en-US');
+}
+
+function formatRelativeTime(unixSeconds: number) {
+  const diff = Date.now() / 1000 - unixSeconds;
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 86400 * 30) return `${Math.floor(diff / 86400)}d ago`;
+  return new Date(unixSeconds * 1000).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
 function MetricCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
@@ -131,6 +147,225 @@ function getExtraStats(category: ProtocolCategory, summary?: ProtocolSummary): E
   return [];
 }
 
+function ProtocolHeader({ config }: { config: ProtocolConfig }) {
+  return (
+    <div className="pb-2 border-b border-[var(--border)]">
+      <div className="flex items-center gap-2 text-xs text-[var(--text-faint)] mb-2">
+        <Link href="/protocols" className="hover:text-[var(--accent)] transition-colors">Protocols</Link>
+        <span>/</span>
+        <span>{config.name}</span>
+      </div>
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span className="w-4 h-4 rounded-full shrink-0" style={{ backgroundColor: config.color }} />
+          <div>
+            <h1 className="text-2xl font-semibold text-[var(--text)]">{config.name}</h1>
+            <p className="text-sm text-[var(--text-muted)] mt-0.5 max-w-2xl">{config.description}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <span className="text-xs text-[var(--text-faint)] bg-[var(--bg-elevated)] border border-[var(--border)] px-2 py-1 rounded-[var(--radius-button)]">
+            {config.chains.join(' · ')}
+          </span>
+          <a
+            href={config.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[var(--accent)] hover:underline"
+          >
+            {config.website.replace('https://', '')} ↗
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OutcomeBadge({ outcome }: { outcome: PredictionMarketsDetail['recentResolutions'][number]['outcome'] }) {
+  const styles: Record<typeof outcome, string> = {
+    YES: 'bg-[var(--green)]/15 text-[var(--green)] border-[var(--green)]/30',
+    NO: 'bg-[#FF5C5C]/15 text-[#FF8585] border-[#FF5C5C]/30',
+    PARTIAL: 'bg-[var(--yellow,#f59e0b)]/15 text-[var(--yellow,#f59e0b)] border-[var(--yellow,#f59e0b)]/30',
+    UNRESOLVED: 'bg-[var(--bg-elevated)] text-[var(--text-faint)] border-[var(--border)]',
+  };
+  return (
+    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${styles[outcome]}`}>
+      {outcome}
+    </span>
+  );
+}
+
+function PredictionMarketsView({
+  config,
+  summary,
+  detail,
+  isLoading,
+}: {
+  config: ProtocolConfig;
+  summary?: ProtocolSummary;
+  detail?: PredictionMarketsDetail;
+  isLoading: boolean;
+}) {
+  const placeholder = isLoading || !detail;
+  return (
+    <div className="space-y-6">
+      <ProtocolHeader config={config} />
+
+      {/* Lifetime KPIs */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <MetricCard
+          label="Lifetime Volume"
+          value={isLoading ? '—' : formatUSD(summary?.cumulativeVolumeUSD ?? 0)}
+          sub="all time"
+        />
+        <MetricCard
+          label="Lifetime Fees"
+          value={isLoading ? '—' : formatUSD(summary?.cumulativeFeesUSD ?? 0)}
+          sub="all time"
+        />
+        <MetricCard
+          label="Total Trades"
+          value={placeholder ? '—' : formatCount(detail.totalTrades)}
+          sub="all time"
+        />
+        <MetricCard
+          label="Avg Trade Size"
+          value={placeholder ? '—' : formatUSD(detail.avgTradeSize)}
+        />
+      </div>
+
+      {/* Ecosystem stats strip */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: 'Active Markets', value: placeholder ? '—' : formatCount(detail.activeMarkets) },
+          { label: 'Resolved Markets', value: placeholder ? '—' : formatCount(detail.resolvedMarkets) },
+          { label: 'Unique Traders', value: placeholder ? '—' : formatCount(detail.totalTraders) },
+          { label: 'Disputed Resolutions', value: placeholder ? '—' : formatCount(detail.disputedCount), sub: detail && detail.disputedCount >= 1000 ? '1000+ tracked' : undefined },
+        ].map((s) => (
+          <div key={s.label} className="p-3 rounded-[var(--radius-button)] bg-[var(--bg-elevated)]/60 border border-[var(--border)]">
+            <p className="text-[10px] text-[var(--text-faint)] mb-0.5">{s.label}</p>
+            <p className="text-sm font-mono font-medium text-[var(--text)]">{s.value}</p>
+            {s.sub && <p className="text-[9px] text-[var(--text-faint)] mt-0.5">{s.sub}</p>}
+          </div>
+        ))}
+      </div>
+
+      {/* Recent Resolutions */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Resolutions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {placeholder ? (
+            <div className="space-y-2">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="h-9 shimmer rounded" />
+              ))}
+            </div>
+          ) : detail.recentResolutions.length === 0 ? (
+            <p className="text-xs text-[var(--text-faint)]">No recent resolutions returned.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[var(--border)]">
+                    <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">Market</th>
+                    <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)] w-20">Outcome</th>
+                    <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)] w-24">Resolved</th>
+                    <th className="text-left py-2 text-[11px] font-medium text-[var(--text-faint)] w-20">Disputed</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detail.recentResolutions.map((r) => (
+                    <tr
+                      key={r.id}
+                      className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-elevated)]/40 transition-colors"
+                    >
+                      <td className="py-2.5 pr-4 text-[var(--text)] max-w-md">
+                        <span className="line-clamp-2 leading-snug">{r.title || r.id.slice(0, 12) + '…'}</span>
+                      </td>
+                      <td className="py-2.5 pr-4">
+                        <OutcomeBadge outcome={r.outcome} />
+                      </td>
+                      <td className="py-2.5 pr-4 text-[var(--text-muted)] font-mono text-xs whitespace-nowrap">
+                        {formatRelativeTime(r.resolvedAt)}
+                      </td>
+                      <td className="py-2.5 text-xs">
+                        {r.wasDisputed ? (
+                          <span className="text-[var(--yellow,#f59e0b)] font-medium">disputed</span>
+                        ) : (
+                          <span className="text-[var(--text-faint)]">no</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Top Markets by Open Interest */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Top Markets by Open Interest</CardTitle>
+            <span className="text-[10px] text-[var(--text-faint)]">includes residual OI from resolved markets</span>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {placeholder ? (
+            <div className="space-y-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="h-9 shimmer rounded" />
+              ))}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[var(--border)]">
+                    <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)] w-8">#</th>
+                    <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">Condition ID</th>
+                    <th className="text-right py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">OI</th>
+                    <th className="text-right py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">Splits</th>
+                    <th className="text-right py-2 text-[11px] font-medium text-[var(--text-faint)]">Merges</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detail.topMarketsByOI.map((m, i) => (
+                    <tr
+                      key={m.id}
+                      className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-elevated)]/40 transition-colors"
+                    >
+                      <td className="py-2.5 pr-4 text-[var(--text-faint)] font-mono text-xs">{i + 1}</td>
+                      <td className="py-2.5 pr-4 text-[var(--text-muted)] font-mono text-xs">
+                        {m.id.slice(0, 10)}…{m.id.slice(-6)}
+                      </td>
+                      <td className="py-2.5 pr-4 text-right font-mono text-[var(--text)] whitespace-nowrap">{formatUSD(m.amountUSD)}</td>
+                      <td className="py-2.5 pr-4 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap">{formatCount(m.splitCount)}</td>
+                      <td className="py-2.5 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap">{formatCount(m.mergeCount)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Footnote on data shape */}
+      {config.knownIssues && (
+        <p className="text-[10px] text-[var(--text-faint)] leading-relaxed max-w-3xl">
+          <span className="font-medium text-[var(--text-muted)]">Note: </span>
+          {config.knownIssues}
+        </p>
+      )}
+    </div>
+  );
+}
+
 export default function ProtocolDetailPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = use(params);
   const config = getProtocol(slug);
@@ -138,7 +373,21 @@ export default function ProtocolDetailPage({ params }: { params: Promise<{ slug:
   if (!config) notFound();
 
   const { data, isLoading } = useProtocolDetail(slug);
-  const { summary, snapshots = [] } = data ?? {};
+  const { summary, snapshots = [], predictionMarkets } = data ?? {};
+
+  // Prediction Markets get a domain-tailored layout (lifetime KPIs, ecosystem
+  // stats, recent resolutions, top markets by OI) instead of the standard
+  // TVL/Volume/Fees + 90d-snapshot pattern that doesn't fit the asset class.
+  if (config.category === 'Prediction Markets') {
+    return (
+      <PredictionMarketsView
+        config={config}
+        summary={summary}
+        detail={predictionMarkets}
+        isLoading={isLoading}
+      />
+    );
+  }
 
   const chartData = snapshots.map((s) => ({
     date: formatDate(s.timestamp),

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { PROTOCOLS } from '@/lib/protocols/config';
+import { PROTOCOLS, type ProtocolCategory, type ProtocolConfig } from '@/lib/protocols/config';
 import { useProtocolsDirectory } from '@/hooks/useProtocols';
+import type { ProtocolSummary } from '@/lib/protocols/fetcher';
 import { formatUSD } from '@/lib/utils';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
 
@@ -11,6 +13,13 @@ const CATEGORY_STYLES: Record<string, string> = {
   'Lending': 'bg-[var(--green)]/10 text-[var(--green)]',
   'Liquid Staking': 'bg-[#00A3FF]/12 text-[#5BC2FF]',
 };
+
+const CATEGORY_FILTERS: Array<'All' | ProtocolCategory> = [
+  'All', 'DEX', 'Lending', 'Liquid Staking',
+];
+
+type SortKey = 'tvl' | 'volume' | 'fees';
+type SortDir = 'asc' | 'desc';
 
 function CategoryBadge({ category }: { category: string }) {
   const styles = CATEGORY_STYLES[category] ?? 'bg-[var(--bg-elevated)] text-[var(--text-muted)]';
@@ -21,8 +30,76 @@ function CategoryBadge({ category }: { category: string }) {
   );
 }
 
+interface SortableHeaderProps {
+  label: string;
+  active: boolean;
+  dir: SortDir;
+  onClick: () => void;
+  className?: string;
+}
+
+function SortableHeader({ label, active, dir, onClick, className }: SortableHeaderProps) {
+  return (
+    <th className={`py-2 text-[11px] font-medium text-[var(--text-faint)] ${className ?? ''}`}>
+      <button
+        type="button"
+        onClick={onClick}
+        className={`inline-flex items-center gap-1 hover:text-[var(--text)] transition-colors ${active ? 'text-[var(--text)]' : ''}`}
+      >
+        {label}
+        <span className="text-[9px] w-2 inline-block">
+          {active ? (dir === 'desc' ? '▼' : '▲') : ''}
+        </span>
+      </button>
+    </th>
+  );
+}
+
+interface DirectoryRow {
+  config: ProtocolConfig;
+  summary: ProtocolSummary | null | undefined;
+  failed: boolean;
+}
+
+const SORT_VALUE: Record<SortKey, (s: ProtocolSummary) => number> = {
+  tvl: (s) => s.tvlUSD,
+  volume: (s) => s.volume30dUSD,
+  fees: (s) => s.fees30dUSD,
+};
+
 export default function ProtocolsPage() {
   const { data: summaries, isLoading } = useProtocolsDirectory();
+  const [category, setCategory] = useState<'All' | ProtocolCategory>('All');
+  const [sortKey, setSortKey] = useState<SortKey>('tvl');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const rows: DirectoryRow[] = useMemo(() => {
+    const all: DirectoryRow[] = PROTOCOLS.map((config, i) => ({
+      config,
+      summary: summaries?.[i],
+      failed: !!summaries && !summaries[i],
+    }));
+
+    const filtered = category === 'All'
+      ? all
+      : all.filter((r) => r.config.category === category);
+
+    const sorted = [...filtered].sort((a, b) => {
+      const av = a.summary ? SORT_VALUE[sortKey](a.summary) : -1;
+      const bv = b.summary ? SORT_VALUE[sortKey](b.summary) : -1;
+      return sortDir === 'desc' ? bv - av : av - bv;
+    });
+    return sorted;
+  }, [summaries, category, sortKey, sortDir]);
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir(sortDir === 'desc' ? 'asc' : 'desc');
+    } else {
+      setSortKey(key);
+      setSortDir('desc');
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -35,9 +112,28 @@ export default function ProtocolsPage() {
 
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <CardTitle>Protocol Directory</CardTitle>
             <span className="text-xs text-[var(--text-faint)]">Data updated hourly · Powered by The Graph</span>
+          </div>
+          <div className="flex flex-wrap gap-1.5 mt-3">
+            {CATEGORY_FILTERS.map((c) => {
+              const active = c === category;
+              return (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setCategory(c)}
+                  className={`text-[11px] px-2 py-1 rounded-[var(--radius-button)] border transition-colors ${
+                    active
+                      ? 'bg-[var(--accent)]/10 border-[var(--accent)]/30 text-[var(--accent)]'
+                      : 'bg-transparent border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--border-mid)] hover:text-[var(--text)]'
+                  }`}
+                >
+                  {c}
+                </button>
+              );
+            })}
           </div>
         </CardHeader>
         <CardContent>
@@ -55,53 +151,74 @@ export default function ProtocolsPage() {
                     <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)] w-8">#</th>
                     <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">Protocol</th>
                     <th className="text-left py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">Category</th>
-                    <th className="text-right py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">TVL</th>
-                    <th className="text-right py-2 pr-4 text-[11px] font-medium text-[var(--text-faint)]">30d Volume</th>
-                    <th className="text-right py-2 text-[11px] font-medium text-[var(--text-faint)]">30d Fees</th>
+                    <SortableHeader
+                      label="TVL"
+                      active={sortKey === 'tvl'}
+                      dir={sortDir}
+                      onClick={() => handleSort('tvl')}
+                      className="text-right pr-4"
+                    />
+                    <SortableHeader
+                      label="30d Volume"
+                      active={sortKey === 'volume'}
+                      dir={sortDir}
+                      onClick={() => handleSort('volume')}
+                      className="text-right pr-4"
+                    />
+                    <SortableHeader
+                      label="30d Fees"
+                      active={sortKey === 'fees'}
+                      dir={sortDir}
+                      onClick={() => handleSort('fees')}
+                      className="text-right"
+                    />
                   </tr>
                 </thead>
                 <tbody>
-                  {PROTOCOLS.map((protocol, i) => {
-                    const summary = summaries?.[i];
-                    const failed = summaries && !summary;
-                    return (
-                      <tr
-                        key={protocol.slug}
-                        className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-elevated)] transition-colors"
-                      >
-                        <td className="py-3 pr-4 text-[var(--text-faint)] font-mono text-xs">{i + 1}</td>
-                        <td className="py-3 pr-4">
-                          <Link
-                            href={`/protocols/${protocol.slug}`}
-                            className="flex items-center gap-2.5 group"
-                          >
-                            <span
-                              className="w-2.5 h-2.5 rounded-full shrink-0"
-                              style={{ backgroundColor: protocol.color }}
-                            />
-                            <span className="font-medium text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
-                              {protocol.name}
-                            </span>
-                            <span className="text-[10px] text-[var(--text-faint)] hidden sm:inline">
-                              {protocol.chains.join(', ')}
-                            </span>
-                          </Link>
-                        </td>
-                        <td className="py-3 pr-4">
-                          <CategoryBadge category={protocol.category} />
-                        </td>
-                        <td className="py-3 pr-4 text-right font-mono text-[var(--text)] whitespace-nowrap">
-                          {failed ? '—' : summary ? formatUSD(summary.tvlUSD) : <span className="text-[var(--text-faint)]">—</span>}
-                        </td>
-                        <td className="py-3 pr-4 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap">
-                          {failed ? '—' : summary ? formatUSD(summary.volume30dUSD) : '—'}
-                        </td>
-                        <td className="py-3 text-right font-mono text-[var(--accent)] text-xs whitespace-nowrap">
-                          {failed ? '—' : summary ? formatUSD(summary.fees30dUSD) : '—'}
-                        </td>
-                      </tr>
-                    );
-                  })}
+                  {rows.map(({ config: protocol, summary, failed }, i) => (
+                    <tr
+                      key={protocol.slug}
+                      className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-elevated)] transition-colors"
+                    >
+                      <td className="py-3 pr-4 text-[var(--text-faint)] font-mono text-xs">{i + 1}</td>
+                      <td className="py-3 pr-4">
+                        <Link
+                          href={`/protocols/${protocol.slug}`}
+                          className="flex items-center gap-2.5 group"
+                        >
+                          <span
+                            className="w-2.5 h-2.5 rounded-full shrink-0"
+                            style={{ backgroundColor: protocol.color }}
+                          />
+                          <span className="font-medium text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
+                            {protocol.name}
+                          </span>
+                          <span className="text-[10px] text-[var(--text-faint)] hidden sm:inline">
+                            {protocol.chains.join(', ')}
+                          </span>
+                        </Link>
+                      </td>
+                      <td className="py-3 pr-4">
+                        <CategoryBadge category={protocol.category} />
+                      </td>
+                      <td className="py-3 pr-4 text-right font-mono text-[var(--text)] whitespace-nowrap">
+                        {failed ? '—' : summary ? formatUSD(summary.tvlUSD) : <span className="text-[var(--text-faint)]">—</span>}
+                      </td>
+                      <td className="py-3 pr-4 text-right font-mono text-[var(--text-muted)] text-xs whitespace-nowrap">
+                        {failed ? '—' : summary ? formatUSD(summary.volume30dUSD) : '—'}
+                      </td>
+                      <td className="py-3 text-right font-mono text-[var(--accent)] text-xs whitespace-nowrap">
+                        {failed ? '—' : summary ? formatUSD(summary.fees30dUSD) : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                  {rows.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="py-8 text-center text-xs text-[var(--text-faint)]">
+                        No protocols match this filter.
+                      </td>
+                    </tr>
+                  )}
                 </tbody>
               </table>
             </div>

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -12,6 +12,7 @@ const CATEGORY_STYLES: Record<string, string> = {
   'DEX': 'bg-[var(--accent)]/10 text-[var(--accent)]',
   'Lending': 'bg-[var(--green)]/10 text-[var(--green)]',
   'Liquid Staking': 'bg-[#00A3FF]/12 text-[#5BC2FF]',
+  'Yield Aggregator': 'bg-[#0657F9]/12 text-[#6E92FF]',
 };
 
 const CATEGORY_FILTERS: Array<'All' | ProtocolCategory> = [

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -13,10 +13,11 @@ const CATEGORY_STYLES: Record<string, string> = {
   'Lending': 'bg-[var(--green)]/10 text-[var(--green)]',
   'Liquid Staking': 'bg-[#00A3FF]/12 text-[#5BC2FF]',
   'Yield Aggregator': 'bg-[#0657F9]/12 text-[#6E92FF]',
+  'Prediction Markets': 'bg-[#2D9CDB]/12 text-[#5FB3E0]',
 };
 
 const CATEGORY_FILTERS: Array<'All' | ProtocolCategory> = [
-  'All', 'DEX', 'Lending', 'Liquid Staking', 'Yield Aggregator',
+  'All', 'DEX', 'Lending', 'Liquid Staking', 'Yield Aggregator', 'Prediction Markets',
 ];
 
 type SortKey = 'category' | 'tvl' | 'volume' | 'fees';
@@ -27,6 +28,7 @@ const CATEGORY_ORDER: Record<ProtocolCategory, number> = {
   'Lending': 1,
   'Liquid Staking': 2,
   'Yield Aggregator': 3,
+  'Prediction Markets': 4,
 };
 
 function CategoryBadge({ category }: { category: string }) {

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -19,8 +19,15 @@ const CATEGORY_FILTERS: Array<'All' | ProtocolCategory> = [
   'All', 'DEX', 'Lending', 'Liquid Staking', 'Yield Aggregator',
 ];
 
-type SortKey = 'tvl' | 'volume' | 'fees';
+type SortKey = 'category' | 'tvl' | 'volume' | 'fees';
 type SortDir = 'asc' | 'desc';
+
+const CATEGORY_ORDER: Record<ProtocolCategory, number> = {
+  'DEX': 0,
+  'Lending': 1,
+  'Liquid Staking': 2,
+  'Yield Aggregator': 3,
+};
 
 function CategoryBadge({ category }: { category: string }) {
   const styles = CATEGORY_STYLES[category] ?? 'bg-[var(--bg-elevated)] text-[var(--text-muted)]';
@@ -62,7 +69,7 @@ interface DirectoryRow {
   failed: boolean;
 }
 
-const SORT_VALUE: Record<SortKey, (s: ProtocolSummary) => number> = {
+const METRIC_SORT_VALUE: Record<Exclude<SortKey, 'category'>, (s: ProtocolSummary) => number> = {
   tvl: (s) => s.tvlUSD,
   volume: (s) => s.volume30dUSD,
   fees: (s) => s.fees30dUSD,
@@ -71,7 +78,7 @@ const SORT_VALUE: Record<SortKey, (s: ProtocolSummary) => number> = {
 export default function ProtocolsPage() {
   const { data: summaries, isLoading } = useProtocolsDirectory();
   const [category, setCategory] = useState<'All' | ProtocolCategory>('All');
-  const [sortKey, setSortKey] = useState<SortKey>('tvl');
+  const [sortKey, setSortKey] = useState<SortKey>('category');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
 
   const rows: DirectoryRow[] = useMemo(() => {
@@ -86,8 +93,15 @@ export default function ProtocolsPage() {
       : all.filter((r) => r.config.category === category);
 
     const sorted = [...filtered].sort((a, b) => {
-      const av = a.summary ? SORT_VALUE[sortKey](a.summary) : -1;
-      const bv = b.summary ? SORT_VALUE[sortKey](b.summary) : -1;
+      if (sortKey === 'category') {
+        const catDelta = CATEGORY_ORDER[a.config.category] - CATEGORY_ORDER[b.config.category];
+        if (catDelta !== 0) return catDelta;
+        const av = a.summary?.tvlUSD ?? -1;
+        const bv = b.summary?.tvlUSD ?? -1;
+        return bv - av;
+      }
+      const av = a.summary ? METRIC_SORT_VALUE[sortKey](a.summary) : -1;
+      const bv = b.summary ? METRIC_SORT_VALUE[sortKey](b.summary) : -1;
       return sortDir === 'desc' ? bv - av : av - bv;
     });
     return sorted;

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -16,7 +16,7 @@ const CATEGORY_STYLES: Record<string, string> = {
 };
 
 const CATEGORY_FILTERS: Array<'All' | ProtocolCategory> = [
-  'All', 'DEX', 'Lending', 'Liquid Staking',
+  'All', 'DEX', 'Lending', 'Liquid Staking', 'Yield Aggregator',
 ];
 
 type SortKey = 'tvl' | 'volume' | 'fees';

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -13,11 +13,12 @@ const CATEGORY_STYLES: Record<string, string> = {
   'Lending': 'bg-[var(--green)]/10 text-[var(--green)]',
   'Liquid Staking': 'bg-[#00A3FF]/12 text-[#5BC2FF]',
   'Yield Aggregator': 'bg-[#0657F9]/12 text-[#6E92FF]',
-  'Prediction Markets': 'bg-[#2D9CDB]/12 text-[#5FB3E0]',
+  'Prediction Markets': 'bg-[#A855F7]/12 text-[#C084FC]',
+  'Bridge': 'bg-[#FFA94D]/12 text-[#FFB870]',
 };
 
 const CATEGORY_FILTERS: Array<'All' | ProtocolCategory> = [
-  'All', 'DEX', 'Lending', 'Liquid Staking', 'Yield Aggregator', 'Prediction Markets',
+  'All', 'DEX', 'Lending', 'Liquid Staking', 'Yield Aggregator', 'Prediction Markets', 'Bridge',
 ];
 
 type SortKey = 'category' | 'tvl' | 'volume' | 'fees';
@@ -28,7 +29,8 @@ const CATEGORY_ORDER: Record<ProtocolCategory, number> = {
   'Lending': 1,
   'Liquid Staking': 2,
   'Yield Aggregator': 3,
-  'Prediction Markets': 4,
+  'Bridge': 4,
+  'Prediction Markets': 5,
 };
 
 function CategoryBadge({ category }: { category: string }) {

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -13,10 +13,12 @@ function getRedis(): Redis {
 }
 
 function hasRedis(): boolean {
-  return !!(
-    (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) ||
-    (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN)
-  );
+  // Treat empty strings as unset. Some deploy targets inject the env keys with
+  // empty values when no Redis is provisioned, which would otherwise route
+  // every cache read/write through an invalid URL and stall on TCP timeout.
+  const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
+  return !!(url && token);
 }
 
 /**

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -218,6 +218,8 @@ export const PROTOCOLS: ProtocolConfig[] = [
 // Maintained by the Polymarket team (per github.com/Polymarket/polymarket-subgraph
 // and PaulieB14/graph-polymarket-mcp).
 export const POLYMARKET_OI_DEPLOYMENT = 'QmbT2MmS2VGbGihiTUmWk6GMc2QYqoT9ZhiupUicYMWt6H';
+export const POLYMARKET_MAIN_DEPLOYMENT = 'QmdyCguLEisTtQFveEkvMhTH7UzjyhnrF9kpvhYeG4QX8a';
+export const POLYMARKET_RESOLUTION_DEPLOYMENT = 'QmZnnrHWCB1Mb8dxxXDxfComjNdaGyRC66W8derjn3XDPg';
 
 export function getProtocol(slug: string): ProtocolConfig | undefined {
   return PROTOCOLS.find(p => p.slug === slug);

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -115,6 +115,17 @@ export const PROTOCOLS: ProtocolConfig[] = [
     knownIssues: 'The upstream subgraph writes $0 to dailyProtocolSideRevenueUSD across all snapshots despite a non-zero cumulative figure. Daily fee charts show no data until this is fixed upstream.',
   },
   {
+    slug: 'spark-lend',
+    name: 'Spark Lend',
+    category: 'Lending',
+    description: 'Aave V3 fork operated by the Sky / MakerDAO ecosystem on Ethereum mainnet, with sDAI yield routing baked into the supply side. The largest Spark deployment by TVL.',
+    subgraphId: 'GbKdmBe4ycCYCQLQSjqGg6UHYoYfbyJyq5WrG35pv1si',
+    schemaType: 'messari-lending',
+    website: 'https://spark.fi',
+    chains: ['Ethereum'],
+    color: '#E07A52',
+  },
+  {
     slug: 'spark-lend-gnosis',
     name: 'Spark Lend (Gnosis)',
     category: 'Lending',

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -162,6 +162,17 @@ export const PROTOCOLS: ProtocolConfig[] = [
     color: '#1A33FF',
   },
   {
+    slug: 'pancakeswap-v3',
+    name: 'PancakeSwap V3',
+    category: 'DEX',
+    description: 'Largest DEX on BNB Chain, with V3 also deployed to Ethereum. Concentrated-liquidity AMM forked from Uniswap V3 with multi-tier fees. This entry tracks the Ethereum mainnet deployment.',
+    subgraphId: 'JAGXF8B14mpB8QGKnwhKTs5JxsQZBJQvbDGFcWwL7gbm',
+    schemaType: 'messari-dex',
+    website: 'https://pancakeswap.finance',
+    chains: ['Ethereum'],
+    color: '#D1884F',
+  },
+  {
     slug: 'ether-fi',
     name: 'ether.fi',
     category: 'Liquid Staking',

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -2,6 +2,7 @@ export type SchemaType =
   | 'messari-dex'
   | 'messari-lending'
   | 'messari-staking'
+  | 'uniswap-v2'
   | 'uniswap-v3';
 
 export type ProtocolCategory =
@@ -34,6 +35,17 @@ export const PROTOCOLS: ProtocolConfig[] = [
     website: 'https://uniswap.org',
     chains: ['Ethereum'],
     color: '#FF007A',
+  },
+  {
+    slug: 'uniswap-v2',
+    name: 'Uniswap V2',
+    category: 'DEX',
+    description: 'The original constant-product AMM that proved permissionless token swaps at scale on Ethereum. Flat 0.30% fee, still the deepest liquidity venue for many long-tail ERC-20 pairs.',
+    subgraphId: 'GmSczqdCDZ3hJeYY9JphwsADn5rePUzUKm8EZcVuhRAm',
+    schemaType: 'uniswap-v2',
+    website: 'https://uniswap.org',
+    chains: ['Ethereum'],
+    color: '#FF6699',
   },
   {
     slug: 'uniswap-v3-polygon',

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -3,8 +3,10 @@ export type SchemaType =
   | 'messari-lending'
   | 'messari-staking'
   | 'messari-yield'
+  | 'messari-bridge'
   | 'uniswap-v2'
   | 'uniswap-v3'
+  | 'algebra-v1'
   | 'etherfi-native'
   | 'polymarket';
 
@@ -13,7 +15,8 @@ export type ProtocolCategory =
   | 'Lending'
   | 'Liquid Staking'
   | 'Yield Aggregator'
-  | 'Prediction Markets';
+  | 'Prediction Markets'
+  | 'Bridge';
 
 export interface ProtocolConfig {
   slug: string;
@@ -27,6 +30,8 @@ export interface ProtocolConfig {
   color: string;
   /** Known upstream data quality issue — surfaced as a notice on the detail page. */
   knownIssues?: string;
+  /** Which 90-day chart the knownIssues message belongs to. Defaults to 'fees'. */
+  knownIssueAffects?: 'fees' | 'volume';
 }
 
 export const PROTOCOLS: ProtocolConfig[] = [
@@ -140,6 +145,8 @@ export const PROTOCOLS: ProtocolConfig[] = [
     website: 'https://spark.fi',
     chains: ['Gnosis'],
     color: '#F58A65',
+    knownIssues: 'The upstream subgraph writes $0 to dailyBorrowUSD across all snapshots while the cumulative borrow figure remains correct. Daily borrowing chart shows no data until this is fixed upstream.',
+    knownIssueAffects: 'volume',
   },
   {
     slug: 'lido',
@@ -175,6 +182,50 @@ export const PROTOCOLS: ProtocolConfig[] = [
     color: '#D1884F',
   },
   {
+    slug: 'uniswap-v3-arbitrum',
+    name: 'Uniswap V3 (Arbitrum)',
+    category: 'DEX',
+    description: 'Uniswap V3 deployment on Arbitrum One. Major L2 venue with deep ARB-ecosystem liquidity, queried via the Messari DEX-AMM schema.',
+    subgraphId: 'FQ6JYszEKApsBpAmiHesRsd9Ygc6mzmpNRANeVQFYoVX',
+    schemaType: 'messari-dex',
+    website: 'https://app.uniswap.org',
+    chains: ['Arbitrum'],
+    color: '#FF007A',
+  },
+  {
+    slug: 'uniswap-v3-optimism',
+    name: 'Uniswap V3 (Optimism)',
+    category: 'DEX',
+    description: 'Uniswap V3 deployment on Optimism. OP-ecosystem trading hub, queried via the Messari DEX-AMM schema.',
+    subgraphId: 'EgnS9YE1avupkvCNj9fHnJxppfEmNNywYJtghqiu2pd9',
+    schemaType: 'messari-dex',
+    website: 'https://app.uniswap.org',
+    chains: ['Optimism'],
+    color: '#FF66B3',
+  },
+  {
+    slug: 'velodrome-v2',
+    name: 'Velodrome V2',
+    category: 'DEX',
+    description: 'Flagship native DEX on Optimism. ve(3,3) AMM with stable and volatile pools and veVELO emissions; the protocol Aerodrome was forked from before launching on Base.',
+    subgraphId: 'A4Y1A82YhSLTn998BVVELC8eWzhi992k4ZitByvssxqA',
+    schemaType: 'messari-dex',
+    website: 'https://velodrome.finance',
+    chains: ['Optimism'],
+    color: '#FF1B6B',
+  },
+  {
+    slug: 'camelot-v3',
+    name: 'Camelot V3',
+    category: 'DEX',
+    description: 'Native Arbitrum DEX with concentrated-liquidity pools built on the Algebra V1 engine, plus dynamic fees and a launchpad pipeline. The most-used non-Uniswap DEX on Arbitrum.',
+    subgraphId: '3utanEBA9nqMjPnuQP1vMCCys6enSM3EawBpKTVwnUw2',
+    schemaType: 'algebra-v1',
+    website: 'https://app.camelot.exchange',
+    chains: ['Arbitrum'],
+    color: '#E8B964',
+  },
+  {
     slug: 'ether-fi',
     name: 'ether.fi',
     category: 'Liquid Staking',
@@ -195,6 +246,52 @@ export const PROTOCOLS: ProtocolConfig[] = [
     website: 'https://yearn.fi',
     chains: ['Ethereum'],
     color: '#0657F9',
+  },
+  {
+    slug: 'stargate-arbitrum',
+    name: 'Stargate (Arbitrum)',
+    category: 'Bridge',
+    description: 'Cross-chain liquidity transport built on LayerZero. Stargate routes native assets across chains via unified pools. This entry tracks the Arbitrum deployment, the highest-volume Stargate venue with $14B+ in lifetime bridge volume.',
+    subgraphId: 'DWo7jrtpTtUM1buqiCUg7j7XUF568qNPBv7FwwDceuxm',
+    schemaType: 'messari-bridge',
+    website: 'https://stargate.finance',
+    chains: ['Arbitrum'],
+    color: '#3CC9F2',
+  },
+  {
+    slug: 'stargate-optimism',
+    name: 'Stargate (Optimism)',
+    category: 'Bridge',
+    description: 'Stargate cross-chain liquidity transport on Optimism. Routes native assets via unified pools. Second-largest Stargate venue by lifetime volume.',
+    subgraphId: '7NAF7ZtNtJiXkfCFkTSAyFbfLLfUFa55UgK5woxPxZ46',
+    schemaType: 'messari-bridge',
+    website: 'https://stargate.finance',
+    chains: ['Optimism'],
+    color: '#FF0420',
+  },
+  {
+    slug: 'cbridge',
+    name: 'cBridge',
+    category: 'Bridge',
+    description: 'Celer Network multi-chain transport routing assets across 40+ chains. Ethereum deployment indexed here, with $10B+ in cumulative bridge volume.',
+    subgraphId: 'DokJsCswtSfoQreapeZDaJR9jAfZ9t4zdNbNqgwM117L',
+    schemaType: 'messari-bridge',
+    website: 'https://cbridge.celer.network',
+    chains: ['Ethereum'],
+    color: '#5BC2F6',
+  },
+  {
+    slug: 'axelar',
+    name: 'Axelar',
+    category: 'Bridge',
+    description: 'Cross-chain communication layer connecting 70+ chains via a proof-of-stake validator network. Ethereum deployment with $45M+ in pool TVL.',
+    subgraphId: '8u1rrGZY3gjXAAVJidygbpKeHzitrMSQV1RoLAkyd1AA',
+    schemaType: 'messari-bridge',
+    website: 'https://axelar.network',
+    chains: ['Ethereum'],
+    color: '#FF6B57',
+    knownIssues: 'The upstream subgraph reports $0 dailyTotalRevenueUSD across all snapshots while bridge volume is healthy. Daily fees chart shows no data until this is fixed upstream.',
+    knownIssueAffects: 'fees',
   },
   {
     slug: 'polymarket',

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -2,6 +2,7 @@ export type SchemaType =
   | 'messari-dex'
   | 'messari-lending'
   | 'messari-staking'
+  | 'messari-yield'
   | 'uniswap-v2'
   | 'uniswap-v3'
   | 'etherfi-native';
@@ -9,7 +10,8 @@ export type SchemaType =
 export type ProtocolCategory =
   | 'DEX'
   | 'Lending'
-  | 'Liquid Staking';
+  | 'Liquid Staking'
+  | 'Yield Aggregator';
 
 export interface ProtocolConfig {
   slug: string;
@@ -169,6 +171,17 @@ export const PROTOCOLS: ProtocolConfig[] = [
     website: 'https://ether.fi',
     chains: ['Ethereum'],
     color: '#A0FFE6',
+  },
+  {
+    slug: 'yearn-v2',
+    name: 'Yearn V2',
+    category: 'Yield Aggregator',
+    description: 'Long-running yield optimisation protocol that routes deposits across vault strategies to maximise returns. The Ethereum mainnet V2 deployment, original automated yield primitive in DeFi.',
+    subgraphId: 'FDLuaz69DbMADuBjJDEcLnTuPnjhZqNbFVrkNiBLGkEg',
+    schemaType: 'messari-yield',
+    website: 'https://yearn.fi',
+    chains: ['Ethereum'],
+    color: '#0657F9',
   },
 ];
 

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -3,7 +3,8 @@ export type SchemaType =
   | 'messari-lending'
   | 'messari-staking'
   | 'uniswap-v2'
-  | 'uniswap-v3';
+  | 'uniswap-v3'
+  | 'etherfi-native';
 
 export type ProtocolCategory =
   | 'DEX'
@@ -157,6 +158,17 @@ export const PROTOCOLS: ProtocolConfig[] = [
     website: 'https://aerodrome.finance',
     chains: ['Base'],
     color: '#1A33FF',
+  },
+  {
+    slug: 'ether-fi',
+    name: 'ether.fi',
+    category: 'Liquid Staking',
+    description: 'Liquid restaking protocol on Ethereum issuing eETH (rebasing) and weETH (wrapped). Stakers earn validator rewards plus EigenLayer restaking yield. Largest LRT by TVL.',
+    subgraphId: 'AEsX7AeqTD9bpFFaHwmCZbEXaHWsmzekoPKKuJUGQiQA',
+    schemaType: 'etherfi-native',
+    website: 'https://ether.fi',
+    chains: ['Ethereum'],
+    color: '#A0FFE6',
   },
 ];
 

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -5,13 +5,15 @@ export type SchemaType =
   | 'messari-yield'
   | 'uniswap-v2'
   | 'uniswap-v3'
-  | 'etherfi-native';
+  | 'etherfi-native'
+  | 'polymarket';
 
 export type ProtocolCategory =
   | 'DEX'
   | 'Lending'
   | 'Liquid Staking'
-  | 'Yield Aggregator';
+  | 'Yield Aggregator'
+  | 'Prediction Markets';
 
 export interface ProtocolConfig {
   slug: string;
@@ -194,7 +196,28 @@ export const PROTOCOLS: ProtocolConfig[] = [
     chains: ['Ethereum'],
     color: '#0657F9',
   },
+  {
+    slug: 'polymarket',
+    name: 'Polymarket',
+    category: 'Prediction Markets',
+    description: 'Largest decentralised prediction-market venue. CLOB-style orderbook on Polygon settling outcome shares against USDC collateral, with over a billion trades on $100B+ of lifetime notional.',
+    // The Polymarket-team deployments are pinned by IPFS hash on the gateway,
+    // not registered Subgraph IDs. The fetcher routes polymarket schemaType
+    // queries to the deployment endpoint.
+    subgraphId: 'QmVGA9vvNZtEquVzDpw8wnTFDxVjB6mavTRMTrKuUBhi4t',
+    schemaType: 'polymarket',
+    website: 'https://polymarket.com',
+    chains: ['Polygon'],
+    color: '#2D9CDB',
+    knownIssues: 'Headline TVL is total cumulative open interest (USDC locked into outstanding outcome tokens) and includes residual "dead money" from resolved markets where losing-side tokens were never burned. 30d windows are not currently computed for Polymarket as the orderbook subgraph has no daily aggregate entity; the directory shows lifetime totals instead.',
+  },
 ];
+
+// Deployment IPFS hashes for Polymarket subgraphs that aren't registered as
+// network Subgraphs but are exposed via the gateway's /deployments/id/ path.
+// Maintained by the Polymarket team (per github.com/Polymarket/polymarket-subgraph
+// and PaulieB14/graph-polymarket-mcp).
+export const POLYMARKET_OI_DEPLOYMENT = 'QmbT2MmS2VGbGihiTUmWk6GMc2QYqoT9ZhiupUicYMWt6H';
 
 export function getProtocol(slug: string): ProtocolConfig | undefined {
   return PROTOCOLS.find(p => p.slug === slug);

--- a/src/lib/protocols/config.ts
+++ b/src/lib/protocols/config.ts
@@ -147,6 +147,17 @@ export const PROTOCOLS: ProtocolConfig[] = [
     chains: ['Ethereum'],
     color: '#00A3FF',
   },
+  {
+    slug: 'aerodrome',
+    name: 'Aerodrome',
+    category: 'DEX',
+    description: 'Largest DEX on Base by TVL and volume. ve(3,3) AMM combining stable, volatile, and concentrated-liquidity (Slipstream) pools, with veAERO emissions directing liquidity.',
+    subgraphId: 'GENunSHWLBXm59mBSgPzQ8metBEp9YDfdqwFr91Av1UM',
+    schemaType: 'uniswap-v3',
+    website: 'https://aerodrome.finance',
+    chains: ['Base'],
+    color: '#1A33FF',
+  },
 ];
 
 export function getProtocol(slug: string): ProtocolConfig | undefined {

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -143,6 +143,38 @@ const MESSARI_STAKING_QUERY = `{
   }
 }`;
 
+// --- Uniswap V2 native schema ---
+//
+// V2 has no fees field on either the factory or the daily snapshot. Every swap
+// pays a flat 0.30% to LPs, so fees are derived from volume at query time.
+
+const UNISWAP_V2_FEE_RATE = 0.003;
+const UNISWAP_V2_FACTORY_ETH = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f';
+
+interface UniswapV2Data {
+  uniswapFactory: {
+    totalVolumeUSD: string;
+    totalLiquidityUSD: string;
+  } | null;
+  uniswapDayDatas: Array<{
+    date: string;
+    dailyVolumeUSD: string;
+    totalLiquidityUSD: string;
+  }>;
+}
+
+const UNISWAP_V2_QUERY = `{
+  uniswapFactory(id: "${UNISWAP_V2_FACTORY_ETH}") {
+    totalVolumeUSD
+    totalLiquidityUSD
+  }
+  uniswapDayDatas(first: 90, orderBy: date, orderDirection: desc) {
+    date
+    dailyVolumeUSD
+    totalLiquidityUSD
+  }
+}`;
+
 // --- Uniswap V3 native schema ---
 
 interface UniswapV3Data {
@@ -331,6 +363,34 @@ function normalizeMessariStaking(slug: string, data: MessariStakingData): Protoc
   };
 }
 
+function normalizeUniswapV2(slug: string, data: UniswapV2Data): ProtocolDetail {
+  const f = data.uniswapFactory;
+  const totalVolume = parseF(f?.totalVolumeUSD);
+  const snapshots: ProtocolDaySnapshot[] = data.uniswapDayDatas
+    .map((s) => {
+      const volumeUSD = parseF(s.dailyVolumeUSD);
+      return {
+        timestamp: parseInt(s.date),
+        tvlUSD: parseF(s.totalLiquidityUSD),
+        volumeUSD,
+        feesUSD: volumeUSD * UNISWAP_V2_FEE_RATE,
+      };
+    })
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const clean = filterFeeOutliers(snapshots);
+  return {
+    summary: computeSummary(
+      slug,
+      parseF(f?.totalLiquidityUSD),
+      totalVolume,
+      totalVolume * UNISWAP_V2_FEE_RATE,
+      clean,
+    ),
+    snapshots: clean,
+  };
+}
+
 function normalizeUniswapV3(slug: string, data: UniswapV3Data): ProtocolDetail {
   const f = data.factories[0];
   const snapshots: ProtocolDaySnapshot[] = data.uniswapDayDatas
@@ -370,6 +430,10 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
     case 'messari-staking': {
       const data = await queryProtocolSubgraph<MessariStakingData>(config.subgraphId, MESSARI_STAKING_QUERY);
       return normalizeMessariStaking(config.slug, data);
+    }
+    case 'uniswap-v2': {
+      const data = await queryProtocolSubgraph<UniswapV2Data>(config.subgraphId, UNISWAP_V2_QUERY);
+      return normalizeUniswapV2(config.slug, data);
     }
     case 'uniswap-v3': {
       const data = await queryProtocolSubgraph<UniswapV3Data>(config.subgraphId, UNISWAP_V3_QUERY);

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -1,4 +1,9 @@
-import { POLYMARKET_OI_DEPLOYMENT, type ProtocolConfig } from './config';
+import {
+  POLYMARKET_OI_DEPLOYMENT,
+  POLYMARKET_MAIN_DEPLOYMENT,
+  POLYMARKET_RESOLUTION_DEPLOYMENT,
+  type ProtocolConfig,
+} from './config';
 
 export interface ProtocolDaySnapshot {
   timestamp: number; // unix seconds
@@ -21,6 +26,39 @@ export interface ProtocolSummary {
 export interface ProtocolDetail {
   summary: ProtocolSummary;
   snapshots: ProtocolDaySnapshot[];
+  /**
+   * Category-specific extension. Populated for protocols whose native data
+   * shape doesn't fit the standard TVL/Volume/Fees + 90d-snapshot pattern
+   * (currently: Prediction Markets). The detail page reads this when the
+   * protocol's category is configured for a tailored layout.
+   */
+  predictionMarkets?: PredictionMarketsDetail;
+}
+
+export interface PredictionMarketsDetail {
+  totalMarkets: number;
+  activeMarkets: number;
+  resolvedMarkets: number;
+  totalTraders: number;
+  totalTrades: number;
+  avgTradeSize: number;
+  marketCountWithOI: number;
+  disputedCount: number;
+  recentResolutions: Array<{
+    id: string;
+    title: string;
+    outcome: 'YES' | 'NO' | 'PARTIAL' | 'UNRESOLVED';
+    outcomePrice: number;       // 0..1
+    resolvedAt: number;          // unix seconds
+    wasDisputed: boolean;
+    flagged: boolean;
+  }>;
+  topMarketsByOI: Array<{
+    id: string;
+    amountUSD: number;
+    splitCount: number;
+    mergeCount: number;
+  }>;
 }
 
 // --- Generic gateway query ---
@@ -254,11 +292,36 @@ interface PolymarketOIData {
   // Used as the "active OI" headline because globalOpenInterests.amount is
   // inflated by resolved-market dead money across 700k+ historical markets.
   marketOpenInterests: Array<{
-    amount: string; // decimal-scaled USDC
+    id: string;
+    amount: string;       // decimal-scaled USDC
+    splitCount: string;
+    mergeCount: string;
   }>;
   globalOpenInterests: Array<{
     marketCount: number;
   }>;
+}
+
+interface PolymarketMainData {
+  globals: Array<{
+    numConditions: string;
+    numOpenConditions: string;
+    numClosedConditions: string;
+    numTraders: string;
+  }>;
+}
+
+interface PolymarketResolutionData {
+  recentResolutions: Array<{
+    id: string;
+    status: string;
+    flagged: boolean;
+    wasDisputed: boolean;
+    price: string;        // 1e18-scaled outcome
+    lastUpdateTimestamp: string;
+    ancillaryData: string;
+  }>;
+  disputedSample: Array<{ id: string }>;
 }
 
 const POLYMARKET_ORDERBOOK_QUERY = `{
@@ -272,27 +335,125 @@ const POLYMARKET_ORDERBOOK_QUERY = `{
 
 const POLYMARKET_OI_QUERY = `{
   marketOpenInterests(first: 200, orderBy: amount, orderDirection: desc, where: {amount_lt: "10000000000"}) {
+    id
     amount
+    splitCount
+    mergeCount
   }
   globalOpenInterests(first: 1) {
     marketCount
   }
 }`;
 
+const POLYMARKET_MAIN_QUERY = `{
+  globals(first: 1) {
+    numConditions
+    numOpenConditions
+    numClosedConditions
+    numTraders
+  }
+}`;
+
+// Resolution returns recent resolved markets (ancillaryData carries the human-
+// readable question text) plus a sample of disputed markets used to size a
+// "Disputed" headline. The disputed bucket is capped at 1000 by the subgraph;
+// for our purposes the lower-bound is sufficient signal.
+const POLYMARKET_RESOLUTION_QUERY = `{
+  recentResolutions: marketResolutions(
+    first: 12,
+    orderBy: lastUpdateTimestamp,
+    orderDirection: desc,
+    where: {status: "resolved"}
+  ) {
+    id
+    status
+    flagged
+    wasDisputed
+    price
+    lastUpdateTimestamp
+    ancillaryData
+  }
+  disputedSample: marketResolutions(first: 1000, where: {wasDisputed: true}) {
+    id
+  }
+}`;
+
+// MarketResolution.ancillaryData is the UMA-encoded UTF-8 prompt sent to the
+// optimistic oracle. It always begins with "q: title: <TITLE>, description: ..."
+// for Polymarket-issued questions. We extract just the title for the UI.
+function decodeMarketTitle(hexAncillary: string): string {
+  if (!hexAncillary || !hexAncillary.startsWith('0x')) return '';
+  try {
+    const buf = Buffer.from(hexAncillary.slice(2), 'hex');
+    const text = buf.toString('utf-8');
+    const match = text.match(/title:\s*(.*?)(?:,\s*description:|$)/);
+    return match ? match[1].trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+function classifyOutcome(priceWei: string): {
+  outcome: 'YES' | 'NO' | 'PARTIAL' | 'UNRESOLVED';
+  outcomePrice: number;
+} {
+  const p = parseF(priceWei) / 1e18;
+  if (!Number.isFinite(p)) return { outcome: 'UNRESOLVED', outcomePrice: 0 };
+  if (p >= 0.99) return { outcome: 'YES', outcomePrice: p };
+  if (p <= 0.01) return { outcome: 'NO', outcomePrice: p };
+  return { outcome: 'PARTIAL', outcomePrice: p };
+}
+
 function normalizePolymarket(
   slug: string,
   orderbook: PolymarketOrderbookData,
   oi: PolymarketOIData,
+  main: PolymarketMainData,
+  resolution: PolymarketResolutionData,
 ): ProtocolDetail {
   const ob = orderbook.ordersMatchedGlobals[0];
   const tvlUSD = oi.marketOpenInterests.reduce((sum, m) => sum + parseF(m.amount), 0);
   const cumulativeVolumeUSD = parseF(ob?.scaledCollateralVolume);
   const cumulativeFeesUSD = parseF(ob?.totalFees) / POLYMARKET_USDC_DECIMALS;
 
+  const g = main.globals[0];
+  const recentResolutions = resolution.recentResolutions.map((r) => {
+    const { outcome, outcomePrice } = classifyOutcome(r.price);
+    return {
+      id: r.id,
+      title: decodeMarketTitle(r.ancillaryData),
+      outcome,
+      outcomePrice,
+      resolvedAt: parseInt(r.lastUpdateTimestamp),
+      wasDisputed: r.wasDisputed,
+      flagged: r.flagged,
+    };
+  });
+
+  const topMarketsByOI = oi.marketOpenInterests.slice(0, 10).map((m) => ({
+    id: m.id,
+    amountUSD: parseF(m.amount),
+    splitCount: parseInt(m.splitCount),
+    mergeCount: parseInt(m.mergeCount),
+  }));
+
+  const predictionMarkets: PredictionMarketsDetail = {
+    totalMarkets: parseInt(g?.numConditions ?? '0'),
+    activeMarkets: parseInt(g?.numOpenConditions ?? '0'),
+    resolvedMarkets: parseInt(g?.numClosedConditions ?? '0'),
+    totalTraders: parseInt(g?.numTraders ?? '0'),
+    totalTrades: parseInt(ob?.tradesQuantity ?? '0'),
+    avgTradeSize: parseF(ob?.averageTradeSize),
+    marketCountWithOI: oi.globalOpenInterests[0]?.marketCount ?? 0,
+    disputedCount: resolution.disputedSample.length,
+    recentResolutions,
+    topMarketsByOI,
+  };
+
   // No daily aggregate entity exists on the orderbook subgraph, and
   // paginating through ~5M trades/day to derive a 30d window is not feasible
-  // at request time. We return an empty snapshots array; the directory shows
-  // lifetime totals and the detail page renders cumulative-only metrics.
+  // at request time. We return an empty snapshots array; the detail page
+  // renders the predictionMarkets-tailored layout instead.
   return {
     summary: {
       slug,
@@ -303,6 +464,7 @@ function normalizePolymarket(
       fees30dUSD: 0,
     },
     snapshots: [],
+    predictionMarkets,
   };
 }
 
@@ -756,11 +918,13 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
       return normalizeEtherFi(config.slug, rebases.rebaseEvents, ethPriceUSD);
     }
     case 'polymarket': {
-      const [orderbook, oi] = await Promise.all([
+      const [orderbook, oi, main, resolution] = await Promise.all([
         queryDeployment<PolymarketOrderbookData>(config.subgraphId, POLYMARKET_ORDERBOOK_QUERY),
         queryDeployment<PolymarketOIData>(POLYMARKET_OI_DEPLOYMENT, POLYMARKET_OI_QUERY),
+        queryDeployment<PolymarketMainData>(POLYMARKET_MAIN_DEPLOYMENT, POLYMARKET_MAIN_QUERY),
+        queryDeployment<PolymarketResolutionData>(POLYMARKET_RESOLUTION_DEPLOYMENT, POLYMARKET_RESOLUTION_QUERY),
       ]);
-      return normalizePolymarket(config.slug, orderbook, oi);
+      return normalizePolymarket(config.slug, orderbook, oi, main, resolution);
     }
   }
 }

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -207,6 +207,62 @@ const UNISWAP_V3_QUERY = `{
   }
 }`;
 
+// --- EtherFi native schema ---
+//
+// ether.fi's v3 subgraph stores values in ETH (BigInt wei) and exposes a
+// stream of `rebaseEvents` carrying the post-rebase totalEthLocked and
+// totalEEthShares. To produce the same TVL/Volume/Fees/APR shape as the
+// other Liquid Staking protocols we:
+//
+//   1. Fetch all rebases in the last ~95 days (5 events/day average).
+//   2. Group by day, take the last event of each day.
+//   3. Derive net yield-to-stakers via the eETH share-price delta:
+//        priceUSD(day) = totalEthLocked(day) / totalEEthShares(day)
+//        yieldEth(day) = sharesPrev * (priceUSD(day) - priceUSD(day-1))
+//      This isolates rebase yield from deposits and withdrawals, since
+//      share price only moves with rebases (deposits mint at par).
+//   4. Multiply by current ETH/USD (fetched in parallel from Uniswap V3
+//      mainnet) for USD denomination. Historic rebases are anchored to
+//      today's ETH price, an acceptable approximation given Lodestar's
+//      'current snapshot' framing.
+//   5. Approximate protocol fees as 10% of supply-side yield, matching
+//      ether.fi's documented protocol take. Replace with a real source
+//      if/when the subgraph exposes it.
+
+const ETHERFI_PROTOCOL_FEE_RATIO = 0.10;
+// ETH mainnet Uniswap V3 subgraph (already used elsewhere in lodestar) —
+// queried only for `bundle.ethPriceUSD` to convert ETH-denominated values.
+const UNISWAP_V3_ETH_MAINNET_SUBGRAPH = '5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV';
+
+interface EtherFiData {
+  rebaseEvents: Array<{
+    timestamp: string;
+    totalEthLocked: string;
+    totalEEthShares: string;
+    aprs: string[];
+  }>;
+}
+
+interface EthPriceData {
+  bundles: Array<{ ethPriceUSD: string }>;
+}
+
+const ETHERFI_QUERY = `{
+  rebaseEvents(
+    first: 1000
+    orderBy: timestamp
+    orderDirection: desc
+    where: { timestamp_gt: "$SINCE" }
+  ) {
+    timestamp
+    totalEthLocked
+    totalEEthShares
+    aprs
+  }
+}`;
+
+const ETH_PRICE_QUERY = `{ bundles(first: 1) { ethPriceUSD } }`;
+
 // --- Shared normalisation ---
 
 function filterFeeOutliers(snapshots: ProtocolDaySnapshot[]): ProtocolDaySnapshot[] {
@@ -391,6 +447,70 @@ function normalizeUniswapV2(slug: string, data: UniswapV2Data): ProtocolDetail {
   };
 }
 
+function normalizeEtherFi(
+  slug: string,
+  rebases: EtherFiData['rebaseEvents'],
+  ethPriceUSD: number,
+): ProtocolDetail {
+  if (rebases.length === 0 || ethPriceUSD <= 0) {
+    return {
+      summary: computeSummary(slug, 0, 0, 0, []),
+      snapshots: [],
+    };
+  }
+
+  // Group rebases by UTC day, keeping the last event of each day.
+  const byDay = new Map<number, EtherFiData['rebaseEvents'][number]>();
+  for (const r of rebases) {
+    const day = Math.floor(parseInt(r.timestamp) / 86400);
+    const existing = byDay.get(day);
+    if (!existing || parseInt(r.timestamp) > parseInt(existing.timestamp)) {
+      byDay.set(day, r);
+    }
+  }
+  const sorted = Array.from(byDay.values()).sort(
+    (a, b) => parseInt(a.timestamp) - parseInt(b.timestamp),
+  );
+
+  const latest = sorted[sorted.length - 1];
+  const tvlUSD = (parseFloat(latest.totalEthLocked) / 1e18) * ethPriceUSD;
+
+  const snapshots: ProtocolDaySnapshot[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const curr = sorted[i];
+    const sharesPrev = parseFloat(prev.totalEEthShares) / 1e18;
+    const sharesCurr = parseFloat(curr.totalEEthShares) / 1e18;
+    const ethPrev = parseFloat(prev.totalEthLocked) / 1e18;
+    const ethCurr = parseFloat(curr.totalEthLocked) / 1e18;
+    const pricePrev = sharesPrev > 0 ? ethPrev / sharesPrev : 1;
+    const priceCurr = sharesCurr > 0 ? ethCurr / sharesCurr : 1;
+    const yieldEth = Math.max(0, sharesPrev * (priceCurr - pricePrev));
+    const yieldUSD = yieldEth * ethPriceUSD;
+    snapshots.push({
+      timestamp: parseInt(curr.timestamp),
+      tvlUSD: ethCurr * ethPriceUSD,
+      volumeUSD: yieldUSD,
+      feesUSD: yieldUSD * ETHERFI_PROTOCOL_FEE_RATIO,
+    });
+  }
+
+  const clean = filterFeeOutliers(snapshots);
+  const cumulativeYield = clean.reduce((sum, s) => sum + s.volumeUSD, 0);
+  const cumulativeFees = clean.reduce((sum, s) => sum + s.feesUSD, 0);
+
+  const last30 = clean.slice(-30);
+  const last30Yield = last30.reduce((sum, s) => sum + s.volumeUSD, 0);
+  const stakingAPR = tvlUSD > 0 && last30.length > 0
+    ? (last30Yield / tvlUSD) * (365 / last30.length) * 100
+    : 0;
+
+  return {
+    summary: computeSummary(slug, tvlUSD, cumulativeYield, cumulativeFees, clean, { stakingAPR }),
+    snapshots: clean,
+  };
+}
+
 function normalizeUniswapV3(slug: string, data: UniswapV3Data): ProtocolDetail {
   const f = data.factories[0];
   const snapshots: ProtocolDaySnapshot[] = data.uniswapDayDatas
@@ -438,6 +558,16 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
     case 'uniswap-v3': {
       const data = await queryProtocolSubgraph<UniswapV3Data>(config.subgraphId, UNISWAP_V3_QUERY);
       return normalizeUniswapV3(config.slug, data);
+    }
+    case 'etherfi-native': {
+      const since = Math.floor(Date.now() / 1000) - 95 * 86400;
+      const query = ETHERFI_QUERY.replace('$SINCE', String(since));
+      const [rebases, price] = await Promise.all([
+        queryProtocolSubgraph<EtherFiData>(config.subgraphId, query),
+        queryProtocolSubgraph<EthPriceData>(UNISWAP_V3_ETH_MAINNET_SUBGRAPH, ETH_PRICE_QUERY),
+      ]);
+      const ethPriceUSD = parseF(price.bundles[0]?.ethPriceUSD);
+      return normalizeEtherFi(config.slug, rebases.rebaseEvents, ethPriceUSD);
     }
   }
 }

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -58,6 +58,10 @@ export interface PredictionMarketsDetail {
     amountUSD: number;
     splitCount: number;
     mergeCount: number;
+    /** Human-readable market question, hydrated from the Polymarket CLOB API. */
+    title?: string;
+    /** URL slug for `polymarket.com/event/{slug}`, if returned by the CLOB API. */
+    slug?: string;
   }>;
 }
 
@@ -235,6 +239,42 @@ const MESSARI_YIELD_QUERY = `{
   }
 }`;
 
+// --- Messari Bridge schema (Hop, Stargate, cBridge, Axelar, Across V2 etc.) ---
+//
+// Standard Messari bridge template: protocol-level `bridgeProtocols` plus
+// `financialsDailySnapshots` with per-chain volumeIn / volumeOut series.
+// We use cumulativeTotalVolumeUSD as the headline cumulative metric and
+// dailyVolumeOutUSD as the daily series so the volume chart shows what
+// users sent through the bridge from this chain.
+
+interface MessariBridgeData {
+  bridgeProtocols: Array<{
+    totalValueLockedUSD: string;
+    cumulativeTotalVolumeUSD: string;
+    cumulativeTotalRevenueUSD: string;
+  }>;
+  financialsDailySnapshots: Array<{
+    timestamp: string;
+    totalValueLockedUSD: string;
+    dailyVolumeOutUSD: string;
+    dailyTotalRevenueUSD: string;
+  }>;
+}
+
+const MESSARI_BRIDGE_QUERY = `{
+  bridgeProtocols(first: 1) {
+    totalValueLockedUSD
+    cumulativeTotalVolumeUSD
+    cumulativeTotalRevenueUSD
+  }
+  financialsDailySnapshots(first: 90, orderBy: timestamp, orderDirection: desc) {
+    timestamp
+    totalValueLockedUSD
+    dailyVolumeOutUSD
+    dailyTotalRevenueUSD
+  }
+}`;
+
 // --- Uniswap V2 native schema ---
 //
 // V2 has no fees field on either the factory or the daily snapshot. Every swap
@@ -356,8 +396,8 @@ const POLYMARKET_MAIN_QUERY = `{
 
 // Resolution returns recent resolved markets (ancillaryData carries the human-
 // readable question text) plus a sample of disputed markets used to size a
-// "Disputed" headline. The disputed bucket is capped at 1000 by the subgraph;
-// for our purposes the lower-bound is sufficient signal.
+// "Disputed" headline. We cap the disputed bucket at 250 — enough for the
+// "250+ tracked" banner while keeping the resolution-subgraph response fast.
 const POLYMARKET_RESOLUTION_QUERY = `{
   recentResolutions: marketResolutions(
     first: 12,
@@ -373,10 +413,39 @@ const POLYMARKET_RESOLUTION_QUERY = `{
     lastUpdateTimestamp
     ancillaryData
   }
-  disputedSample: marketResolutions(first: 1000, where: {wasDisputed: true}) {
+  disputedSample: marketResolutions(first: 250, where: {wasDisputed: true}) {
     id
   }
 }`;
+
+// Polymarket CLOB API exposes per-condition market metadata — title, slug,
+// description, status, etc. Used to hydrate top-OI condition IDs into
+// human-readable rows in the UI. Hits run inside the cached fetch path so
+// the per-condition HTTP cost is amortised over the 1-hour cache window.
+const POLYMARKET_CLOB_BASE = 'https://clob.polymarket.com/markets';
+const POLYMARKET_CLOB_TIMEOUT_MS = 4000;
+
+interface ClobMarketResponse {
+  condition_id?: string;
+  question?: string;
+  market_slug?: string;
+}
+
+async function fetchClobMarket(conditionId: string): Promise<ClobMarketResponse | null> {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), POLYMARKET_CLOB_TIMEOUT_MS);
+    const res = await fetch(`${POLYMARKET_CLOB_BASE}/${conditionId}`, {
+      signal: ctrl.signal,
+      headers: { Accept: 'application/json' },
+    });
+    clearTimeout(t);
+    if (!res.ok) return null;
+    return (await res.json()) as ClobMarketResponse;
+  } catch {
+    return null;
+  }
+}
 
 // MarketResolution.ancillaryData is the UMA-encoded UTF-8 prompt sent to the
 // optimistic oracle. It always begins with "q: title: <TITLE>, description: ..."
@@ -493,6 +562,42 @@ const UNISWAP_V3_QUERY = `{
     txCount
   }
   uniswapDayDatas(first: 90, orderBy: date, orderDirection: desc) {
+    date
+    volumeUSD
+    feesUSD
+    tvlUSD
+  }
+}`;
+
+// --- Algebra V1 schema (Camelot V3 etc.) ---
+//
+// Algebra is the concentrated-liquidity engine Camelot V3 uses. Same Factory
+// + day-data shape as Uniswap V3 except the day entity is `algebraDayDatas`.
+// We fetch with the renamed entity and reuse normalizeUniswapV3 unchanged.
+
+interface AlgebraV1Data {
+  factories: Array<{
+    totalVolumeUSD: string;
+    totalValueLockedUSD: string;
+    totalFeesUSD: string;
+    txCount: string;
+  }>;
+  algebraDayDatas: Array<{
+    date: string;
+    volumeUSD: string;
+    feesUSD: string;
+    tvlUSD: string;
+  }>;
+}
+
+const ALGEBRA_V1_QUERY = `{
+  factories(first: 1) {
+    totalVolumeUSD
+    totalValueLockedUSD
+    totalFeesUSD
+    txCount
+  }
+  algebraDayDatas(first: 90, orderBy: date, orderDirection: desc) {
     date
     volumeUSD
     feesUSD
@@ -763,6 +868,33 @@ function normalizeMessariYield(slug: string, data: MessariYieldData): ProtocolDe
   };
 }
 
+function normalizeMessariBridge(slug: string, data: MessariBridgeData): ProtocolDetail {
+  const p = data.bridgeProtocols[0];
+  const snapshots: ProtocolDaySnapshot[] = data.financialsDailySnapshots
+    .map((s) => ({
+      timestamp: parseInt(s.timestamp),
+      tvlUSD: parseF(s.totalValueLockedUSD),
+      volumeUSD: parseF(s.dailyVolumeOutUSD),
+      feesUSD: parseF(s.dailyTotalRevenueUSD),
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const clean = filterFeeOutliers(snapshots);
+  const snapshotVolumeSum = clean.reduce((acc, s) => acc + s.volumeUSD, 0);
+  const snapshotFeesSum = clean.reduce((acc, s) => acc + s.feesUSD, 0);
+
+  return {
+    summary: computeSummary(
+      slug,
+      parseF(p?.totalValueLockedUSD),
+      sanitizeCumulative(parseF(p?.cumulativeTotalVolumeUSD), snapshotVolumeSum),
+      sanitizeCumulative(parseF(p?.cumulativeTotalRevenueUSD), snapshotFeesSum),
+      clean,
+    ),
+    snapshots: clean,
+  };
+}
+
 function normalizeUniswapV2(slug: string, data: UniswapV2Data): ProtocolDetail {
   const f = data.uniswapFactory;
   const totalVolume = parseF(f?.totalVolumeUSD);
@@ -899,6 +1031,10 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
       const data = await queryProtocolSubgraph<MessariYieldData>(config.subgraphId, MESSARI_YIELD_QUERY);
       return normalizeMessariYield(config.slug, data);
     }
+    case 'messari-bridge': {
+      const data = await queryProtocolSubgraph<MessariBridgeData>(config.subgraphId, MESSARI_BRIDGE_QUERY);
+      return normalizeMessariBridge(config.slug, data);
+    }
     case 'uniswap-v2': {
       const data = await queryProtocolSubgraph<UniswapV2Data>(config.subgraphId, UNISWAP_V2_QUERY);
       return normalizeUniswapV2(config.slug, data);
@@ -906,6 +1042,13 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
     case 'uniswap-v3': {
       const data = await queryProtocolSubgraph<UniswapV3Data>(config.subgraphId, UNISWAP_V3_QUERY);
       return normalizeUniswapV3(config.slug, data);
+    }
+    case 'algebra-v1': {
+      const data = await queryProtocolSubgraph<AlgebraV1Data>(config.subgraphId, ALGEBRA_V1_QUERY);
+      return normalizeUniswapV3(config.slug, {
+        factories: data.factories,
+        uniswapDayDatas: data.algebraDayDatas,
+      });
     }
     case 'etherfi-native': {
       const since = Math.floor(Date.now() / 1000) - 95 * 86400;
@@ -924,7 +1067,20 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
         queryDeployment<PolymarketMainData>(POLYMARKET_MAIN_DEPLOYMENT, POLYMARKET_MAIN_QUERY),
         queryDeployment<PolymarketResolutionData>(POLYMARKET_RESOLUTION_DEPLOYMENT, POLYMARKET_RESOLUTION_QUERY),
       ]);
-      return normalizePolymarket(config.slug, orderbook, oi, main, resolution);
+      const detail = normalizePolymarket(config.slug, orderbook, oi, main, resolution);
+      // Hydrate top-OI condition IDs with human-readable market questions from
+      // the Polymarket CLOB API. Fan out in parallel and tolerate per-request
+      // failures so a single 404/timeout doesn't blank the whole table.
+      if (detail.predictionMarkets) {
+        const top = detail.predictionMarkets.topMarketsByOI;
+        const lookups = await Promise.allSettled(top.map((m) => fetchClobMarket(m.id)));
+        detail.predictionMarkets.topMarketsByOI = top.map((m, i) => {
+          const r = lookups[i];
+          if (r.status !== 'fulfilled' || !r.value) return m;
+          return { ...m, title: r.value.question, slug: r.value.market_slug };
+        });
+      }
+      return detail;
     }
   }
 }

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -1,4 +1,4 @@
-import type { ProtocolConfig } from './config';
+import { POLYMARKET_OI_DEPLOYMENT, type ProtocolConfig } from './config';
 
 export interface ProtocolDaySnapshot {
   timestamp: number; // unix seconds
@@ -35,6 +35,24 @@ async function queryProtocolSubgraph<T>(subgraphId: string, query: string): Prom
     body: JSON.stringify({ query }),
   });
   if (!res.ok) throw new Error(`Protocol subgraph request failed: ${res.status}`);
+  const json = await res.json();
+  if (json.errors) throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
+  return json.data as T;
+}
+
+// IPFS-pinned deployments that aren't registered as network Subgraphs but are
+// served by the gateway via /deployments/id/{hash}. Used for Polymarket where
+// the team publishes data through unregistered deployment hashes.
+async function queryDeployment<T>(ipfsHash: string, query: string): Promise<T> {
+  const apiKey = process.env.GRAPH_API_KEY;
+  if (!apiKey) throw new Error('GRAPH_API_KEY not configured');
+  const url = `https://gateway.thegraph.com/api/${apiKey}/deployments/id/${ipfsHash}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  });
+  if (!res.ok) throw new Error(`Deployment request failed: ${res.status}`);
   const json = await res.json();
   if (json.errors) throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
   return json.data as T;
@@ -210,6 +228,83 @@ const UNISWAP_V2_QUERY = `{
     totalLiquidityUSD
   }
 }`;
+
+// --- Polymarket multi-deployment schema ---
+//
+// Polymarket data lives across two unregistered IPFS deployments served by
+// the gateway: an Orderbook subgraph (lifetime trade volume + fees + count)
+// and an Open Interest subgraph (aggregate USDC locked across markets).
+// We use the OI total as a TVL proxy. The orderbook subgraph has no daily
+// aggregate entity, so 30d windows are not computed for this protocol;
+// directory cells will render as 0 / "—" for the 30d columns.
+
+const POLYMARKET_USDC_DECIMALS = 1_000_000;
+
+interface PolymarketOrderbookData {
+  ordersMatchedGlobals: Array<{
+    tradesQuantity: string;
+    scaledCollateralVolume: string; // already decimal-scaled by the subgraph
+    totalFees: string;              // raw USDC, needs /1e6
+    averageTradeSize: string;
+  }>;
+}
+
+interface PolymarketOIData {
+  // Top markets by OI, excluding obvious single-market outliers (>$10B).
+  // Used as the "active OI" headline because globalOpenInterests.amount is
+  // inflated by resolved-market dead money across 700k+ historical markets.
+  marketOpenInterests: Array<{
+    amount: string; // decimal-scaled USDC
+  }>;
+  globalOpenInterests: Array<{
+    marketCount: number;
+  }>;
+}
+
+const POLYMARKET_ORDERBOOK_QUERY = `{
+  ordersMatchedGlobals(first: 1) {
+    tradesQuantity
+    scaledCollateralVolume
+    totalFees
+    averageTradeSize
+  }
+}`;
+
+const POLYMARKET_OI_QUERY = `{
+  marketOpenInterests(first: 200, orderBy: amount, orderDirection: desc, where: {amount_lt: "10000000000"}) {
+    amount
+  }
+  globalOpenInterests(first: 1) {
+    marketCount
+  }
+}`;
+
+function normalizePolymarket(
+  slug: string,
+  orderbook: PolymarketOrderbookData,
+  oi: PolymarketOIData,
+): ProtocolDetail {
+  const ob = orderbook.ordersMatchedGlobals[0];
+  const tvlUSD = oi.marketOpenInterests.reduce((sum, m) => sum + parseF(m.amount), 0);
+  const cumulativeVolumeUSD = parseF(ob?.scaledCollateralVolume);
+  const cumulativeFeesUSD = parseF(ob?.totalFees) / POLYMARKET_USDC_DECIMALS;
+
+  // No daily aggregate entity exists on the orderbook subgraph, and
+  // paginating through ~5M trades/day to derive a 30d window is not feasible
+  // at request time. We return an empty snapshots array; the directory shows
+  // lifetime totals and the detail page renders cumulative-only metrics.
+  return {
+    summary: {
+      slug,
+      tvlUSD,
+      cumulativeVolumeUSD,
+      cumulativeFeesUSD,
+      volume30dUSD: 0,
+      fees30dUSD: 0,
+    },
+    snapshots: [],
+  };
+}
 
 // --- Uniswap V3 native schema ---
 
@@ -659,6 +754,13 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
       ]);
       const ethPriceUSD = parseF(price.bundles[0]?.ethPriceUSD);
       return normalizeEtherFi(config.slug, rebases.rebaseEvents, ethPriceUSD);
+    }
+    case 'polymarket': {
+      const [orderbook, oi] = await Promise.all([
+        queryDeployment<PolymarketOrderbookData>(config.subgraphId, POLYMARKET_ORDERBOOK_QUERY),
+        queryDeployment<PolymarketOIData>(POLYMARKET_OI_DEPLOYMENT, POLYMARKET_OI_QUERY),
+      ]);
+      return normalizePolymarket(config.slug, orderbook, oi);
     }
   }
 }

--- a/src/lib/protocols/fetcher.ts
+++ b/src/lib/protocols/fetcher.ts
@@ -143,6 +143,42 @@ const MESSARI_STAKING_QUERY = `{
   }
 }`;
 
+// --- Messari Yield Aggregator schema (used by Yearn V2 Ethereum and similar).
+//
+// Mirrors the Messari Staking shape: same field names, same dailyProtocolSide=0
+// quirk, same proportional fee back-derivation. The only difference is the
+// protocol-level entity is `yieldAggregators` instead of `protocols`.
+
+interface MessariYieldData {
+  yieldAggregators: Array<{
+    totalValueLockedUSD: string;
+    cumulativeSupplySideRevenueUSD: string;
+    cumulativeProtocolSideRevenueUSD: string;
+    cumulativeTotalRevenueUSD: string;
+  }>;
+  financialsDailySnapshots: Array<{
+    timestamp: string;
+    totalValueLockedUSD: string;
+    dailySupplySideRevenueUSD: string;
+    dailyProtocolSideRevenueUSD: string;
+  }>;
+}
+
+const MESSARI_YIELD_QUERY = `{
+  yieldAggregators(first: 1) {
+    totalValueLockedUSD
+    cumulativeSupplySideRevenueUSD
+    cumulativeProtocolSideRevenueUSD
+    cumulativeTotalRevenueUSD
+  }
+  financialsDailySnapshots(first: 90, orderBy: timestamp, orderDirection: desc) {
+    timestamp
+    totalValueLockedUSD
+    dailySupplySideRevenueUSD
+    dailyProtocolSideRevenueUSD
+  }
+}`;
+
 // --- Uniswap V2 native schema ---
 //
 // V2 has no fees field on either the factory or the daily snapshot. Every swap
@@ -419,6 +455,57 @@ function normalizeMessariStaking(slug: string, data: MessariStakingData): Protoc
   };
 }
 
+function normalizeMessariYield(slug: string, data: MessariYieldData): ProtocolDetail {
+  // Same back-derivation pattern as normalizeMessariStaking: yield-aggregator
+  // subgraphs leave dailyProtocolSideRevenueUSD at 0 in snapshots while the
+  // cumulative figure is correct. We back-derive a daily protocol fee using
+  // the cumulative protocol/supply ratio so the fees chart renders.
+  const p = data.yieldAggregators[0];
+  const cumulativeSupply = parseF(p?.cumulativeSupplySideRevenueUSD);
+  const cumulativeProtocol = parseF(p?.cumulativeProtocolSideRevenueUSD);
+  const protocolFeeRatio = cumulativeSupply > 0
+    ? cumulativeProtocol / cumulativeSupply
+    : 0;
+
+  const snapshots: ProtocolDaySnapshot[] = data.financialsDailySnapshots
+    .map((s) => {
+      const supply = parseF(s.dailySupplySideRevenueUSD);
+      const reportedProtocol = parseF(s.dailyProtocolSideRevenueUSD);
+      const fees = reportedProtocol > 0 ? reportedProtocol : supply * protocolFeeRatio;
+      return {
+        timestamp: parseInt(s.timestamp),
+        tvlUSD: parseF(s.totalValueLockedUSD),
+        volumeUSD: supply,
+        feesUSD: fees,
+      };
+    })
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const clean = filterFeeOutliers(snapshots);
+  const snapshotVolumeSum = clean.reduce((acc, s) => acc + s.volumeUSD, 0);
+  const snapshotFeesSum = clean.reduce((acc, s) => acc + s.feesUSD, 0);
+
+  // 30d-window APY estimate, identical formula to Liquid Staking.
+  const tvl = parseF(p?.totalValueLockedUSD);
+  const last30 = clean.slice(-30);
+  const last30Yield = last30.reduce((sum, d) => sum + d.volumeUSD, 0);
+  const stakingAPR = tvl > 0 && last30.length > 0
+    ? (last30Yield / tvl) * (365 / last30.length) * 100
+    : 0;
+
+  return {
+    summary: computeSummary(
+      slug,
+      tvl,
+      sanitizeCumulative(cumulativeSupply, snapshotVolumeSum),
+      sanitizeCumulative(cumulativeProtocol, snapshotFeesSum),
+      clean,
+      { stakingAPR },
+    ),
+    snapshots: clean,
+  };
+}
+
 function normalizeUniswapV2(slug: string, data: UniswapV2Data): ProtocolDetail {
   const f = data.uniswapFactory;
   const totalVolume = parseF(f?.totalVolumeUSD);
@@ -550,6 +637,10 @@ export async function fetchProtocolDetail(config: ProtocolConfig): Promise<Proto
     case 'messari-staking': {
       const data = await queryProtocolSubgraph<MessariStakingData>(config.subgraphId, MESSARI_STAKING_QUERY);
       return normalizeMessariStaking(config.slug, data);
+    }
+    case 'messari-yield': {
+      const data = await queryProtocolSubgraph<MessariYieldData>(config.subgraphId, MESSARI_YIELD_QUERY);
+      return normalizeMessariYield(config.slug, data);
     }
     case 'uniswap-v2': {
       const data = await queryProtocolSubgraph<UniswapV2Data>(config.subgraphId, UNISWAP_V2_QUERY);

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,7 +1,13 @@
 import { Redis } from '@upstash/redis';
 
 // Standalone Redis instance — does NOT import logger or cache to stay edge-runtime safe.
-const redis = Redis.fromEnv();
+// When the Upstash env is unset (or set to empty strings, as some deploy targets do),
+// `Redis.fromEnv()` would still construct a client pointed at an invalid URL and every
+// `incr` call would block on a multi-second TCP timeout before failing open. Skip the
+// client construction entirely in that case so middleware short-circuits instantly.
+const redisUrl = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
+const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
+const redis = redisUrl && redisToken ? Redis.fromEnv() : null;
 
 // [path pattern, requests per minute]
 const LIMITS: Array<[RegExp, number]> = [
@@ -19,6 +25,12 @@ export async function rateLimit(
   path: string,
 ): Promise<{ allowed: boolean; remaining: number; limit: number }> {
   const limit = LIMITS.find(([re]) => re.test(path))?.[1] ?? 200;
+
+  if (!redis) {
+    // No Redis configured — let every request through. Production deployments
+    // are expected to wire up Upstash; local/dev runs without it.
+    return { allowed: true, remaining: limit, limit };
+  }
 
   // Fixed 1-minute window keyed by (ip, top-level route segment, minute bucket)
   const bucket = Math.floor(Date.now() / 60_000);


### PR DESCRIPTION
## Summary

Bundles 13 commits expanding the protocols directory from **9 protocols / 2 categories** (live) to **23 protocols / 6 categories**.

Per-protocol additions are split into atomic commits (one per protocol or one per cohesive feature), so every entry is easy to review or revert in isolation.

## Whatʼs new

### New categories (4)
- **Yield Aggregator** (with Yearn V2)
- **Prediction Markets** (with Polymarket and a tailored detail page)
- **Bridge** (with new `messari-bridge` schemaType + 4 bridges below)
- **Restaking** is *not* in this PR. ether.fi lives under Liquid Staking for now.

### New protocols (14)

| Category | Protocol | Chain | Schema |
|---|---|---|---|
| DEX | Uniswap V2 | Ethereum | `uniswap-v2` |
| DEX | Aerodrome | Base | `uniswap-v3` |
| DEX | PancakeSwap V3 | Ethereum | `messari-dex` |
| DEX | Uniswap V3 | Arbitrum | `messari-dex` |
| DEX | Uniswap V3 | Optimism | `messari-dex` |
| DEX | Velodrome V2 | Optimism | `messari-dex` |
| DEX | Camelot V3 | Arbitrum | `algebra-v1` *(new)* |
| Lending | Spark Lend | Ethereum | `messari-lending` |
| Lending | Spark Lend | Gnosis | `messari-lending` |
| Liquid Staking | ether.fi | Ethereum | `etherfi-native` *(custom)* |
| Yield Aggregator | Yearn V2 | Ethereum | `messari-yield` |
| Prediction Markets | Polymarket | Polygon | `polymarket` *(custom)* |
| Bridge | Stargate (Arbitrum) | Arbitrum | `messari-bridge` |
| Bridge | Stargate (Optimism) | Optimism | `messari-bridge` |
| Bridge | cBridge | Multichain | `messari-bridge` |
| Bridge | Axelar | Multichain | `messari-bridge` |

### New schemaTypes (3)
- `messari-bridge`: standard Messari bridgeProtocol shape with `cumulativeTotalVolumeUSD` + `dailyVolumeOutUSD`.
- `algebra-v1`: same Factory shape as Uniswap V3 but renames the day-data entity to `algebraDayDatas`. Reuses the Uniswap V3 normalizer to avoid duplication; only the query string and one type differ.
- `polymarket`: multi-deployment fan-out (Orderbook + OI + Main + Resolution subgraphs) with CLOB-API hydration of human-readable market questions.

### Detail-page upgrades
- **Category-aware labels**: each category renders the metrics that make sense for it (e.g. "Total Borrowed" for Lending, "30d Bridged Out" for Bridge, "Open Interest" for Prediction Markets).
- **`knownIssueAffects: 'fees' | 'volume'` field**: routes upstream-data deficiency notices to the correct 90-day chart so a healthy chart on the same page isn't suppressed. Used by:
  - Spark Lend (Gnosis): zero `dailyBorrowUSD` upstream → notice on the volume chart.
  - Axelar: zero `dailyTotalRevenueUSD` upstream → notice on the fees chart.
  - Morpho Blue: fee anomaly → notice on the fees chart.
- **Polymarket detail page**: top markets by OI with question text, recent resolutions panel, OI vs lifetime-volume distinction.

### Infra hardening
- `cache.ts` and `rate-limit.ts` now treat empty `UPSTASH_REDIS_REST_URL` / `KV_REST_API_URL` env vars as unset. Some deploy targets inject empty strings when no Redis is provisioned, which previously caused multi-second TCP timeouts on every request before failing open. Fix: gate client construction on both URL **and** token being non-empty; rate-limit middleware short-circuits to `{ allowed: true }` when Redis isnʼt configured.

## Verification

All new subgraph IDs probed against `gateway-arbitrum.network.thegraph.com` for sync state and schema fit before being added to config.ts. Each subgraph returned non-zero TVL/volume and was at chain head with no indexing errors at the time of submission.

For the new DEX entries (today's batch):

| Slug | Subgraph ID | TVL | Daily volume |
|---|---|---|---|
| `uniswap-v3-arbitrum` | `FQ6JYszEKApsBpAmiHesRsd9Ygc6mzmpNRANeVQFYoVX` | \$119M | \$56M |
| `uniswap-v3-optimism` | `EgnS9YE1avupkvCNj9fHnJxppfEmNNywYJtghqiu2pd9` | \$13.7M | \$312k |
| `velodrome-v2` | `A4Y1A82YhSLTn998BVVELC8eWzhi992k4ZitByvssxqA` | \$16.8M | \$145k |
| `camelot-v3` | `3utanEBA9nqMjPnuQP1vMCCys6enSM3EawBpKTVwnUw2` | \$15.6M | \$4.7M |

## Type-check

`npx tsc --noEmit` reports the **same 55 errors** on this branch as on `origin/main`. All 55 are pre-existing NextRequest/Request typing issues in `src/app/api/__tests__/` test files; none are introduced by this PR.

## Test plan

- [ ] Spin up `npm run dev`, open `/protocols`, verify directory shows 23 rows and 6 category filters
- [ ] Click into a Bridge entry (e.g. Stargate Arbitrum) and verify the detail page uses Bridge labels (`30d Bridged Out`, `Daily Bridge Volume (90 days)`)
- [ ] Open Spark Lend (Gnosis) and confirm the volume-chart notice renders, fees chart unblocked
- [ ] Open Axelar and confirm the fees-chart notice renders, volume chart unblocked
- [ ] Open Camelot V3 and confirm TVL/volume chart populates (validates the new `algebra-v1` schemaType)
- [ ] Open Polymarket and confirm top-markets and recent-resolutions panels populate