### PR TITLE
feat(tokens): cross-chain Aave V3 + Hyperliquid perps + UX polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ next-env.d.ts
 # local dev artifacts
 /logs/
 /.playwright-screens/
+/.playwright-cli/

--- a/src/app/tokens/[chain]/[address]/page.tsx
+++ b/src/app/tokens/[chain]/[address]/page.tsx
@@ -4,8 +4,10 @@ import { use, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { TokenPriceChart, type WindowId } from '@/components/charts/TokenPriceChart';
+import { ProtocolIcon, defiLlamaSlugFor } from '@/components/tokens/ProtocolIcon';
 import { TagBadge } from '@/components/tokens/TagBadge';
 import { TokenIcon } from '@/components/tokens/TokenIcon';
+import { ChainIcon } from '@/components/tokens/ChainIcon';
 import { useTokenDetail } from '@/hooks/useTokens';
 import { useClickTracking, type TradeClickEvent } from '@/hooks/useClickTracking';
 import { formatCompact, formatNumber, formatPrice, formatUSD, shortenAddress } from '@/lib/utils';
@@ -171,7 +173,856 @@ function Range24h({ range, change }: { range: TokenDetail['range24h']; change: n
   );
 }
 
-function Markets({ markets, chain, onTradeClick }: { markets: TokenDetail['markets']; chain: string; onTradeClick?: (e: TradeClickEvent) => void }) {
+// Inline help tooltip. Wraps a label with a small ⓘ glyph that shows a
+// styled popover on hover — replaces native `title=` attributes, which
+// have a 1+ second delay and don't theme to the rest of the surface.
+// CSS-only (no JS state); positioned below the trigger and capped width.
+function HelpTooltip({
+  label,
+  children,
+  className = '',
+}: {
+  label: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span className={`group relative inline-flex items-center gap-1 cursor-help ${className}`}>
+      {label}
+      <span aria-hidden className="text-[var(--text-faint)] text-[10px]">ⓘ</span>
+      <span
+        role="tooltip"
+        className="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-opacity absolute z-30 top-full left-1/2 -translate-x-1/2 mt-1 w-60 rounded-md bg-[var(--bg-elevated)] border border-[var(--border)] px-3 py-2 text-xs text-[var(--text-muted)] normal-case tracking-normal font-normal text-left pointer-events-none shadow-lg"
+      >
+        {children}
+      </span>
+    </span>
+  );
+}
+
+// Sticky identity strip — pinned to the top of the viewport on scroll so
+// the user never loses track of which token they're looking at. Shows
+// just the essentials: back link, logo, symbol, live price, 24h change.
+// Always visible, slim by design (~32px); the full header below it
+// carries the rest of the surface area.
+function StickyTokenBar({ summary }: { summary: TokenDetail['summary'] }) {
+  return (
+    <div className="sticky top-0 z-20 px-4 sm:px-6 py-1.5 bg-[var(--bg)]/85 backdrop-blur border-b border-[var(--border)]">
+      <div className="max-w-[1280px] mx-auto flex items-center gap-2.5 text-sm">
+        <Link
+          href="/tokens"
+          className="text-xs text-[var(--text-faint)] hover:text-[var(--text)]"
+          title="Back to tokens"
+        >
+          ←
+        </Link>
+        <TokenIcon
+          symbol={summary.symbol}
+          slug={summary.icon}
+          logoUri={summary.logoUri}
+          contract={summary.contract}
+          chain={summary.chain}
+          size={20}
+        />
+        <span className="font-medium">{summary.symbol}</span>
+        <span className="text-xs text-[var(--text-faint)] hidden sm:inline">{summary.name}</span>
+        {summary.priceUsd != null && (
+          <span className="ml-auto tabular-nums text-[var(--text)]">{formatPrice(summary.priceUsd)}</span>
+        )}
+        {summary.change24hPct != null && (
+          <span
+            className={`tabular-nums text-xs ${
+              summary.change24hPct >= 0 ? 'text-[var(--green)]' : 'text-red-500'
+            }`}
+          >
+            {summary.change24hPct >= 0 ? '+' : ''}{summary.change24hPct.toFixed(2)}%
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Compact info row under the header — replaces the old standalone Info
+// card now that the layout is single-column. Surfaces the contract
+// address (linked + copyable), token decimals, and the project website
+// inline with the rest of the header metadata. Circulating / total
+// supply intentionally not duplicated here — they're already visible in
+// the stat cards (Mcap is `priceUsd × circulating`, FDV is `× totalSupply`).
+function HeaderInfoRow({
+  contract,
+  decimals,
+  website,
+  name,
+  alt,
+}: {
+  contract: string;
+  decimals: number;
+  website: string | null;
+  name: string;
+  alt: TokenDetail['summary']['altContracts'];
+}) {
+  let host: string | null = null;
+  if (website) {
+    try { host = new URL(website).host.replace(/^www\./, ''); } catch {}
+  }
+  const altEntries = Object.entries(alt).filter(([, addr]) => !!addr) as Array<[string, string]>;
+  return (
+    <div className="mt-2 flex items-center flex-wrap gap-x-3 gap-y-1 text-xs text-[var(--text-faint)]">
+      <span className="inline-flex items-center gap-1.5">
+        <span className="uppercase tracking-wider text-[10px]">Contract</span>
+        <a
+          href={`https://etherscan.io/token/${contract}`}
+          target="_blank"
+          rel="noreferrer"
+          className="font-mono text-[var(--text-muted)] hover:text-[var(--accent)]"
+        >
+          {shortenAddress(contract, 6)}
+        </a>
+        <CopyButton text={contract} />
+      </span>
+      <span className="inline-flex items-center gap-1.5">
+        <span className="uppercase tracking-wider text-[10px]">Decimals</span>
+        <span className="tabular-nums text-[var(--text-muted)]">{decimals}</span>
+      </span>
+      {altEntries.length > 0 && (
+        <span className="inline-flex items-center gap-1.5">
+          <span className="uppercase tracking-wider text-[10px]">Also on</span>
+          {altEntries.map(([chain, addr]) => {
+            const ex = EXPLORERS[chain];
+            if (!ex) return null;
+            return (
+              <a
+                key={chain}
+                href={`${ex.tx}${addr}`}
+                target="_blank"
+                rel="noreferrer"
+                title={`${ex.name}: ${addr}`}
+                className="inline-flex items-center px-1.5 py-0 rounded border border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+              >
+                {ex.name}
+              </a>
+            );
+          })}
+        </span>
+      )}
+      {website && (
+        <a
+          href={website}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 text-[var(--text-muted)] hover:text-[var(--accent)]"
+        >
+          <span>Visit {name}</span>
+          {host && <span className="text-[var(--text-faint)]">· {host}</span>}
+          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+          </svg>
+        </a>
+      )}
+    </div>
+  );
+}
+
+// Anchor-chip strip that doubles as a quick TOC and a feature index.
+// Renders a chip per section actually present on this token's detail
+// page, each scrolling smoothly to a `<section id>` further down.
+// Sections that aren't applicable (e.g. no Hyperliquid market) drop out
+// — the chip itself signals which protocols/venues this token touches.
+function SectionNav({ data }: { data: TokenDetail }) {
+  type Chip = { id: string; label: string; meta?: string };
+  const chips: Chip[] = [{ id: 'chart', label: 'Chart' }];
+  if (data.recentSwaps.length > 0) {
+    chips.push({ id: 'swaps', label: 'Swaps', meta: String(data.recentSwaps.length) });
+  }
+  if (data.markets.length > 0) {
+    chips.push({ id: 'markets', label: 'Spot pools', meta: String(data.markets.length) });
+  }
+  if (data.lending && data.lending.markets.length > 0) {
+    const n = data.lending.markets.length;
+    chips.push({ id: 'lending', label: 'Aave V3', meta: `${n} ${n === 1 ? 'chain' : 'chains'}` });
+  }
+  if (data.hyperliquid) {
+    chips.push({ id: 'perps', label: 'Hyperliquid', meta: data.hyperliquid.coin });
+  }
+  if (data.topHolders.length > 0) {
+    chips.push({ id: 'holders', label: 'Holders' });
+  }
+  if (chips.length <= 1) return null;
+  return (
+    <div className="mt-3 flex flex-wrap gap-1.5">
+      {chips.map((c) => (
+        <a
+          key={c.id}
+          href={`#${c.id}`}
+          className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-[var(--border)] bg-[var(--bg-elevated)]/40 text-xs text-[var(--text-muted)] hover:border-[var(--accent)] hover:bg-[var(--accent)]/10 hover:text-[var(--text)] transition-colors"
+        >
+          <span>{c.label}</span>
+          {c.meta && (
+            <span className="text-[10px] tabular-nums text-[var(--text-faint)]">{c.meta}</span>
+          )}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+// Tiny inline sparkline. SVG-only, no library; maps the input array to a
+// polyline normalized over the range. Used inside Hyperliquid stat cells.
+function Sparkline({
+  data,
+  width = 60,
+  height = 16,
+  className = '',
+  zeroLine = false,
+}: {
+  data: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+  zeroLine?: boolean;
+}) {
+  if (data.length < 2) return null;
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const dx = width / (data.length - 1);
+  const points = data
+    .map((v, i) => `${(i * dx).toFixed(1)},${(height - ((v - min) / range) * height).toFixed(1)}`)
+    .join(' ');
+  // When `zeroLine` is true, draw a dashed midline for series that
+  // straddle zero (funding rates, where positive vs negative is the
+  // bullish/bearish signal).
+  const zeroY = min < 0 && max > 0 ? height - ((0 - min) / range) * height : null;
+  return (
+    <svg width={width} height={height} className={className} viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+      {zeroLine && zeroY != null && (
+        <line x1={0} x2={width} y1={zeroY} y2={zeroY} stroke="currentColor" strokeWidth={0.5} strokeDasharray="2 2" opacity={0.4} />
+      )}
+      <polyline points={points} fill="none" stroke="currentColor" strokeWidth={1.2} />
+    </svg>
+  );
+}
+
+// Hyperliquid perps card. Renders open interest, funding, 24h volume,
+// and 24h liquidation activity for tokens with a corresponding HL perp
+// market (BTC, ETH, SOL, LINK, AAVE, UNI, …). Returns null otherwise.
+function HyperliquidCard({
+  hyperliquid,
+  summary,
+}: {
+  hyperliquid: TokenDetail['hyperliquid'];
+  summary: TokenDetail['summary'];
+}) {
+  if (!hyperliquid) return null;
+  const symbol = summary.symbol;
+  const fundingPct = hyperliquid.fundingAnnualized * 100;
+  const fundingClass =
+    Math.abs(fundingPct) < 0.5
+      ? 'text-[var(--text-muted)]'
+      : fundingPct > 0
+        ? 'text-[var(--green)]'
+        : 'text-red-500';
+  const liq = hyperliquid.liquidations24h;
+  // Long/short bar fill ratio. The bar is rendered (further down) only
+  // when total notional > 0, and the proportional split fills the full
+  // bar — a perfectly balanced day shows half-red / half-green, not an
+  // empty track. Days with zero liquidations omit the strip entirely.
+  const liqTotal = liq?.totalNotionalUsd ?? 0;
+  const longPct = liq && liqTotal > 0 ? (liq.longNotionalUsd / liqTotal) * 100 : 0;
+  // OI 24h delta — color the subline by sign so the eye picks up
+  // accumulation vs unwinding without reading the number.
+  const oiChange = hyperliquid.openInterestChange24h;
+  const oiChangeClass =
+    oiChange == null
+      ? 'text-[var(--text-faint)]'
+      : oiChange > 0.001
+        ? 'text-[var(--green)]'
+        : oiChange < -0.001
+          ? 'text-red-500'
+          : 'text-[var(--text-faint)]';
+  // Trader-positioning split. Counts (number of accounts on each side)
+  // are a sentiment proxy distinct from notional balance — useful when
+  // a few whales tilt the dollars but most traders sit the other way.
+  const pos = hyperliquid.positioning;
+  const posTotal = pos ? pos.longCount + pos.shortCount : 0;
+  const longCountPct = pos && posTotal > 0 ? (pos.longCount / posTotal) * 100 : 0;
+  // Volume buy/sell split — surfaces directional flow that's already in
+  // the snapshot but wasn't being exposed.
+  const volBuy = hyperliquid.volume24hBuyUsd;
+  const volSell = hyperliquid.volume24hSellUsd;
+  // Perp 24h price change — colored signed pill next to the title.
+  const perpChange = hyperliquid.priceChange24h * 100;
+  const perpChangeClass =
+    perpChange > 0.05 ? 'text-[var(--green)]' : perpChange < -0.05 ? 'text-red-500' : 'text-[var(--text-muted)]';
+  // Perp-vs-spot premium / discount. Compares the HL mark price to our
+  // canonical spot. Larger magnitudes signal aggressive directional
+  // pressure on the venue (longs lifting offers / shorts hitting bids).
+  // For HL's k-prefixed memes (kPEPE, kSHIB, kFLOKI), the perp's mark
+  // price is quoted per 1000 underlying tokens; scale the spot
+  // reference up by 1000 so the comparison is apples-to-apples.
+  const kContract = hyperliquid.coin.startsWith('k');
+  const spotRef =
+    summary.priceUsd != null && summary.priceUsd > 0
+      ? summary.priceUsd * (kContract ? 1000 : 1)
+      : null;
+  const premium =
+    spotRef != null && spotRef > 0 ? (hyperliquid.priceUsd - spotRef) / spotRef : null;
+  const premiumPct = premium != null ? premium * 100 : null;
+  // Regime read — a one-line synthesis above the stat grid that does
+  // the interpretation a trader would otherwise have to do by scanning
+  // four cells. Keeps the card oriented around "what's the signal" not
+  // "here's a bunch of inventory."
+  const regimeParts: string[] = [];
+  if (hyperliquid.fundingAtBaseline) {
+    regimeParts.push('Funding at HL baseline (no skew)');
+  } else if (Math.abs(hyperliquid.fundingAnnualized) >= 0.30) {
+    regimeParts.push(
+      `${hyperliquid.fundingAnnualized > 0 ? 'Heavy long-pay' : 'Heavy short-pay'} funding`
+    );
+  } else if (Math.abs(hyperliquid.fundingAnnualized) >= 0.15) {
+    regimeParts.push(
+      `${hyperliquid.fundingAnnualized > 0 ? 'Long-biased' : 'Short-biased'} funding`
+    );
+  }
+  if (oiChange != null) {
+    if (oiChange >= 0.05) regimeParts.push(`OI accumulating (+${(oiChange * 100).toFixed(1)}% 24h)`);
+    else if (oiChange <= -0.05) regimeParts.push(`OI unwinding (${(oiChange * 100).toFixed(1)}% 24h)`);
+  }
+  if (premiumPct != null && Math.abs(premiumPct) >= 0.20) {
+    regimeParts.push(`perp ${premiumPct >= 0 ? 'premium' : 'discount'} ${premiumPct >= 0 ? '+' : ''}${premiumPct.toFixed(2)}% vs spot`);
+  }
+  // Trader positioning — single-color dominance gauge instead of a
+  // long/short split. The split-color version conflicted with the
+  // liquidation row, where opposite colors mean opposite things; a
+  // one-sided fill against a midline avoids that visual collision.
+  // longCountPct ∈ [0,100] above; we render a 50% midline as the
+  // "neutral" reference and fill from 50% out toward the dominant side.
+  const dominantSide: 'long' | 'short' = longCountPct >= 50 ? 'long' : 'short';
+  const dominantPct = dominantSide === 'long' ? longCountPct : 100 - longCountPct;
+  const fundingPersistent = hyperliquid.fundingHistory24h.length >= 6;
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-3 flex-wrap">
+          <TokenIcon
+            symbol={summary.symbol}
+            slug={summary.icon}
+            logoUri={summary.logoUri}
+            contract={summary.contract}
+            chain={summary.chain}
+            size={24}
+          />
+          <CardTitle>{symbol} perps on Hyperliquid</CardTitle>
+          <span
+            className={`tabular-nums text-sm ${perpChangeClass}`}
+            title="24h price change on the Hyperliquid perp itself, separate from the spot price shown in the page header."
+          >
+            {perpChange >= 0 ? '+' : ''}{perpChange.toFixed(2)}%
+          </span>
+          <a
+            href={hyperliquid.marketUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="ml-auto inline-flex items-center gap-1.5 text-xs text-[var(--text-muted)] hover:text-[var(--accent)] whitespace-nowrap"
+          >
+            <ProtocolIcon slug="hyperliquid" size={18} />
+            Open {hyperliquid.coin} market
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+            </svg>
+          </a>
+        </div>
+        {regimeParts.length > 0 && (
+          <p className="mt-1 text-xs text-[var(--text-muted)] leading-snug">
+            <span className="text-[var(--text-faint)]">Regime: </span>
+            {regimeParts.join(' · ')}
+          </p>
+        )}
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">
+              <HelpTooltip label="Open Interest">
+                Total notional value of open perpetual contracts on Hyperliquid for this asset. A proxy for trader exposure / leverage in the venue. The line below shows 24h delta + a sparkline of hourly OI.
+              </HelpTooltip>
+            </div>
+            <div className="tabular-nums mt-0.5">{formatUSD(hyperliquid.openInterestUsd)}</div>
+            <div className="text-[10px] text-[var(--text-faint)] tabular-nums mt-0.5">
+              {formatNumber(Math.round(hyperliquid.openInterestTokens))} {hyperliquid.coin}
+            </div>
+            {oiChange != null && (
+              <div className={`flex items-center gap-1.5 mt-0.5 ${oiChangeClass}`}>
+                <span className="text-[10px] tabular-nums">
+                  {oiChange >= 0 ? '+' : ''}{(oiChange * 100).toFixed(2)}% (24h)
+                </span>
+                {hyperliquid.openInterestHistory24h.length >= 2 && (
+                  <Sparkline data={hyperliquid.openInterestHistory24h} width={48} height={12} />
+                )}
+              </div>
+            )}
+          </div>
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">24h Volume</div>
+            <div className="tabular-nums mt-0.5">{formatUSD(hyperliquid.volume24hUsd)}</div>
+            {(volBuy > 0 || volSell > 0) && (
+              <div className="text-[10px] text-[var(--text-faint)] tabular-nums mt-0.5">
+                <span className="text-[var(--green)]">B {formatUSD(volBuy)}</span>
+                {' · '}
+                <span className="text-red-500">S {formatUSD(volSell)}</span>
+              </div>
+            )}
+          </div>
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">
+              <HelpTooltip label="Funding (ann.)">
+                Annualized funding rate (hourly funding × 24 × 365). Positive = longs pay shorts (long-biased venue). Negative = shorts pay longs. The sparkline below shows the last 24h of hourly rates with a dashed midline at zero. "At floor" means HL's per-asset baseline; not a directional signal.
+              </HelpTooltip>
+            </div>
+            <div className={`tabular-nums mt-0.5 ${fundingClass}`}>
+              {fundingPct >= 0 ? '+' : ''}{fundingPct.toFixed(2)}%
+            </div>
+            {fundingPersistent && (
+              <div className={`flex items-center gap-1.5 mt-0.5 ${fundingClass}`}>
+                <Sparkline data={hyperliquid.fundingHistory24h} width={56} height={14} zeroLine />
+                {hyperliquid.fundingAtBaseline && (
+                  <span className="text-[10px] text-[var(--text-faint)]">at floor</span>
+                )}
+              </div>
+            )}
+          </div>
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">
+              <HelpTooltip label="Liqs (UTC day)">
+                Notional USD value of liquidation events accumulated so far in the current UTC day, summed across long and short closeouts. Resets at 00:00 UTC. The bar below splits long vs short notional.
+              </HelpTooltip>
+            </div>
+            <div className="tabular-nums mt-0.5">{liq ? formatUSD(liq.totalNotionalUsd) : '—'}</div>
+            {liq && (
+              <div className="text-[10px] text-[var(--text-faint)] tabular-nums mt-0.5">
+                {liq.events} {liq.events === 1 ? 'event' : 'events'} · {liq.uniqueUsers} users
+              </div>
+            )}
+          </div>
+        </div>
+        {pos && posTotal > 0 && (
+          <div className="mt-3 space-y-1">
+            <div className="flex items-center justify-between text-[10px]">
+              <span className="text-[var(--text-muted)]">
+                Longs · {formatNumber(pos.longCount)} ({longCountPct.toFixed(0)}%)
+              </span>
+              <span
+                className="text-[var(--text-faint)]"
+                title="Open positions right now on this market, by account count. Useful as a sentiment proxy distinct from the notional dollar split."
+              >
+                Trader positioning · {dominantPct.toFixed(0)}% {dominantSide}
+              </span>
+              <span className="text-[var(--text-muted)]">
+                ({(100 - longCountPct).toFixed(0)}%) Shorts · {formatNumber(pos.shortCount)}
+              </span>
+            </div>
+            {/* Single-color dominance gauge with a midline marker. The
+               left/right colors that previously matched the liquidations
+               row caused a visual collision; this version reads as
+               "how far from neutral" without competing with the bar
+               below it. Fills outward from the 50% midline toward the
+               dominant side. */}
+            <div className="relative h-1.5 rounded-full bg-[var(--text-faint)]/15 overflow-hidden">
+              <div
+                className="absolute top-0 bottom-0 bg-[var(--accent)]/60"
+                style={
+                  dominantSide === 'long'
+                    ? { left: '50%', width: `${(longCountPct - 50).toFixed(2)}%` }
+                    : { right: '50%', width: `${(50 - longCountPct).toFixed(2)}%` }
+                }
+              />
+              <div
+                className="absolute top-0 bottom-0 w-px bg-[var(--text-faint)]/40"
+                style={{ left: '50%' }}
+              />
+            </div>
+          </div>
+        )}
+        {liq && liqTotal > 0 && (
+          <div className="mt-3 space-y-1">
+            <div className="flex items-center justify-between text-[10px] text-[var(--text-faint)]">
+              <span>Longs liquidated · {formatUSD(liq.longNotionalUsd)}</span>
+              <span>Shorts liquidated · {formatUSD(liq.shortNotionalUsd)}</span>
+            </div>
+            <div className="h-1.5 rounded-full bg-[var(--text-faint)]/15 overflow-hidden flex">
+              <div className="h-full bg-red-500/70" style={{ width: `${longPct.toFixed(2)}%` }} />
+              <div className="h-full bg-[var(--green)]/70" style={{ width: `${(100 - longPct).toFixed(2)}%` }} />
+            </div>
+          </div>
+        )}
+        {hyperliquid.largestLiquidation24h && (
+          <div className="mt-3 text-[11px] text-[var(--text-muted)]">
+            Largest liquidation today:{' '}
+            <span className={hyperliquid.largestLiquidation24h.side === 'long' ? 'text-red-500' : 'text-[var(--green)]'}>
+              {formatUSD(hyperliquid.largestLiquidation24h.notionalUsd)} {hyperliquid.largestLiquidation24h.side}
+            </span>{' '}
+            wiped ·{' '}
+            <a
+              href={`https://app.hyperliquid.xyz/explorer/address/${hyperliquid.largestLiquidation24h.user}`}
+              target="_blank"
+              rel="noreferrer"
+              className="font-mono text-[10px] hover:text-[var(--accent)]"
+            >
+              {shortenAddress(hyperliquid.largestLiquidation24h.user, 5)}
+            </a>
+          </div>
+        )}
+        <div className="mt-3 pt-2 border-t border-[var(--border)]/50 text-[10px] text-[var(--text-faint)] flex flex-wrap gap-x-3 gap-y-0.5">
+          <span>
+            Mark{' '}
+            <span className="text-[var(--text-muted)] tabular-nums">{formatPrice(hyperliquid.priceUsd)}</span>
+            {kContract && <span className="text-[var(--text-faint)]"> per 1k {summary.symbol}</span>}
+          </span>
+          {hyperliquid.priceLow24h != null && hyperliquid.priceHigh24h != null && (
+            <span>
+              24h range{' '}
+              <span className="text-[var(--text-muted)] tabular-nums">
+                {formatPrice(hyperliquid.priceLow24h)} – {formatPrice(hyperliquid.priceHigh24h)}
+              </span>
+            </span>
+          )}
+          {premiumPct != null && (
+            <span title="Mark price on the Hyperliquid perp vs the Uniswap V3 mainnet spot reference.">
+              Perp vs spot{' '}
+              <span
+                className={
+                  Math.abs(premiumPct) < 0.05
+                    ? 'text-[var(--text-muted)]'
+                    : premiumPct > 0
+                      ? 'text-[var(--green)]'
+                      : 'text-red-500'
+                }
+              >
+                {Math.abs(premiumPct) < 0.05 ? '~0.00%' : `${premiumPct >= 0 ? '+' : ''}${premiumPct.toFixed(2)}%`}
+              </span>
+            </span>
+          )}
+          {hyperliquid.trades24h > 0 && (
+            <span>
+              24h activity{' '}
+              <span className="text-[var(--text-muted)] tabular-nums">
+                {formatNumber(hyperliquid.trades24h)} trades · {formatNumber(hyperliquid.uniqueUsers24h)} traders
+              </span>
+            </span>
+          )}
+          <span className="ml-auto">via Pinax Token API</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// Lending-market card. Surfaces total supplied / borrowed / utilization
+// and current rates for tokens listed in supported lending protocols
+// (Aave V3 across Ethereum + Arbitrum + Base + Polygon + Optimism).
+// Renders nothing when the token isn't a lending-market asset — that's
+// most of the catalog.
+function LendingCard({
+  lending,
+  summary,
+}: {
+  lending: TokenDetail['lending'];
+  summary: TokenDetail['summary'];
+}) {
+  if (!lending || lending.markets.length === 0) return null;
+  const symbol = summary.symbol;
+  // Map LendingChain → human-readable label. Local helper, kept close
+  // to the only consumer.
+  const chainLabel: Record<typeof lending.markets[number]['chain'], string> = {
+    mainnet: 'Ethereum',
+    arbitrum: 'Arbitrum',
+    base: 'Base',
+    polygon: 'Polygon',
+    optimism: 'Optimism',
+  };
+  const aggSuppliedUsd = lending.totalSuppliedUsd;
+  const aggBorrowedUsd = lending.totalBorrowedUsd;
+  const aggAvailableUsd = lending.availableLiquidityUsd;
+  const aggUtilPct = lending.utilization != null ? lending.utilization * 100 : null;
+  // Best-of teaser: the row a user is most likely to act on. "Best supply"
+  // = chain paying the highest yield to depositors; "cheapest borrow" =
+  // chain charging the lowest rate to borrowers. Constrained to active
+  // markets so a frozen / supply-only deployment can't headline a stat.
+  const eligible = lending.markets.filter((m) => m.isActive && !m.isFrozen);
+  const bestSupply = eligible.reduce<typeof lending.markets[number] | null>(
+    (best, m) => (best == null || m.supplyApr > best.supplyApr ? m : best),
+    null
+  );
+  const cheapestBorrow = eligible
+    .filter((m) => m.borrowingEnabled)
+    .reduce<typeof lending.markets[number] | null>(
+      (best, m) => (best == null || m.variableBorrowApr < best.variableBorrowApr ? m : best),
+      null
+    );
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-3 flex-wrap">
+          <TokenIcon
+            symbol={summary.symbol}
+            slug={summary.icon}
+            logoUri={summary.logoUri}
+            contract={summary.contract}
+            chain={summary.chain}
+            size={24}
+          />
+          <CardTitle>{symbol} on Aave V3 Core</CardTitle>
+          <span className="ml-auto text-[10px] text-[var(--text-faint)]">via The Graph subgraphs</span>
+        </div>
+        <p className="mt-1 text-xs text-[var(--text-muted)] leading-snug">
+          You can <span className="text-[var(--green)]">supply {symbol}</span> to earn yield, or post it as
+          collateral to <span className="text-[var(--text)]">borrow</span> other assets. Each row below is the
+          same {symbol} market on a different chain — Aave's deployments price risk independently, so APRs vary.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {lending.markets.length > 1 && (
+            // Aggregate strip — only meaningful when there's more than one
+            // deployment to roll up. Sits at the top so the headline
+            // multi-chain numbers read first.
+            <div className="rounded-md bg-[var(--text-faint)]/5 px-3 py-2 space-y-2">
+              <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">All chains combined</div>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+                <div>
+                  <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">Supplied</div>
+                  <div className="tabular-nums mt-0.5">{aggSuppliedUsd != null ? formatUSD(aggSuppliedUsd) : '—'}</div>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">Borrowed</div>
+                  <div className="tabular-nums mt-0.5">{aggBorrowedUsd != null ? formatUSD(aggBorrowedUsd) : '—'}</div>
+                </div>
+                <div>
+                  <div
+                    className="text-[10px] uppercase tracking-wider text-[var(--text-faint)] cursor-help"
+                    title="Total liquidity available to borrow right now across every Aave V3 deployment listing this asset."
+                  >
+                    Available
+                  </div>
+                  <div className="tabular-nums mt-0.5">{aggAvailableUsd != null ? formatUSD(aggAvailableUsd) : '—'}</div>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">Utilization</div>
+                  <div className="tabular-nums mt-0.5">{aggUtilPct != null ? `${aggUtilPct.toFixed(1)}%` : '—'}</div>
+                </div>
+              </div>
+            </div>
+          )}
+          {(bestSupply || cheapestBorrow) && (
+            // "Best-of" teaser — the row a user with this token is most
+            // likely to act on. Calls out the highest-yield supply venue
+            // and the cheapest borrow venue so they don't have to scan the
+            // table for the same conclusion.
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+              {bestSupply && (
+                <div className="rounded-md border border-[var(--border)] px-3 py-2">
+                  <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">
+                    Best Supply APR
+                  </div>
+                  <div className="mt-0.5 flex items-baseline gap-2">
+                    <span className="tabular-nums text-base text-[var(--green)]">{(bestSupply.supplyApr * 100).toFixed(2)}%</span>
+                    <span className="inline-flex items-center gap-1.5 text-[var(--text-muted)]">
+                      on <ChainIcon chain={bestSupply.chain} size={18} /> {chainLabel[bestSupply.chain]}
+                    </span>
+                  </div>
+                </div>
+              )}
+              {cheapestBorrow && (
+                <div className="rounded-md border border-[var(--border)] px-3 py-2">
+                  <div className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">
+                    Cheapest Borrow APR
+                  </div>
+                  <div className="mt-0.5 flex items-baseline gap-2">
+                    <span className="tabular-nums text-base text-[var(--text)]">{(cheapestBorrow.variableBorrowApr * 100).toFixed(2)}%</span>
+                    <span className="inline-flex items-center gap-1.5 text-[var(--text-muted)]">
+                      on <ChainIcon chain={cheapestBorrow.chain} size={18} /> {chainLabel[cheapestBorrow.chain]}
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+          {/* Per-chain table — replaces the previous stack of mini-cards
+             with utilization bars, which read like a project timeline. A
+             table is visually honest about "this is rate-and-balance data
+             across deployments" rather than implying sequential progress. */}
+          <div className="overflow-x-auto -mx-4 sm:mx-0">
+            <table className="w-full text-xs">
+              <thead className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">
+                <tr className="border-b border-[var(--border)]">
+                  <th className="text-left font-medium py-1.5 pl-4 sm:pl-2">Chain</th>
+                  <th className="text-right font-medium py-1.5 px-2">
+                    <HelpTooltip
+                      label="Supplied"
+                      className="justify-end"
+                    >
+                      Total {symbol} (in USD) that lenders have deposited into this pool. The "of cap" line below is how full it is against Aave's per-asset supply ceiling.
+                    </HelpTooltip>
+                  </th>
+                  <th className="text-right font-medium py-1.5 px-2">
+                    <HelpTooltip
+                      label="Borrowed"
+                      className="justify-end"
+                    >
+                      Total {symbol} (in USD) currently being borrowed against this pool. The "of cap" line shows how close it is to the protocol's borrow ceiling.
+                    </HelpTooltip>
+                  </th>
+                  <th className="text-right font-medium py-1.5 px-2">
+                    <HelpTooltip
+                      label="To borrow"
+                      className="justify-end"
+                    >
+                      USD liquidity that's actually borrowable from the pool right now (Supplied minus Borrowed, minus any reserves the protocol withholds).
+                    </HelpTooltip>
+                  </th>
+                  <th className="text-right font-medium py-1.5 px-2">
+                    <HelpTooltip
+                      label="Util"
+                      className="justify-end"
+                    >
+                      Utilization = Borrowed ÷ Supplied. Higher means borrowers have absorbed most of the supply, which pushes both APRs up. Color: amber ≥80%, red ≥95%.
+                    </HelpTooltip>
+                  </th>
+                  <th className="text-right font-medium py-1.5 px-2">
+                    <HelpTooltip
+                      label="Supply APR"
+                      className="justify-end"
+                    >
+                      Annualized yield <span className="text-[var(--green)]">paid to you</span> when you supply {symbol} to this pool. Moves per-block as utilization shifts.
+                    </HelpTooltip>
+                  </th>
+                  <th className="text-right font-medium py-1.5 px-2">
+                    <HelpTooltip
+                      label="Borrow APR"
+                      className="justify-end"
+                    >
+                      Annualized rate <span className="text-[var(--text)]">you pay</span> if you borrow {symbol} (variable rate). Always higher than Supply APR — Aave keeps the spread.
+                    </HelpTooltip>
+                  </th>
+                  <th className="text-right font-medium py-1.5 px-2">
+                    <HelpTooltip
+                      label="Liq. LTV"
+                      className="justify-end"
+                    >
+                      Liquidation threshold. If you post {symbol} as collateral, your loan can be liquidated once the loan-to-value crosses this percentage. Higher = more borrowing room.
+                    </HelpTooltip>
+                  </th>
+                  <th className="py-1.5 pr-4 sm:pr-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {lending.markets.map((m) => {
+                  const utilPct = m.utilization * 100;
+                  const supplyAprPct = m.supplyApr * 100;
+                  const borrowAprPct = m.variableBorrowApr * 100;
+                  const supplyCapPct =
+                    m.supplyCapTokens != null && m.supplyCapTokens > 0
+                      ? (m.totalSuppliedTokens / m.supplyCapTokens) * 100
+                      : null;
+                  const borrowCapPct =
+                    m.borrowCapTokens != null && m.borrowCapTokens > 0
+                      ? (m.totalBorrowedTokens / m.borrowCapTokens) * 100
+                      : null;
+                  // Cap subline color: amber ≥80%, red ≥95%, "at cap" once
+                  // the actual balance has exceeded the cap (Aave's wind-
+                  // down pattern, e.g. Optimism USDC.e with borrowCap=1).
+                  const capColor = (pct: number) =>
+                    pct >= 95 ? 'text-red-500' : pct >= 80 ? 'text-amber-500' : 'text-[var(--text-faint)]';
+                  // Utilization color encodes the same "load" signal the
+                  // old bar carried, but inline with the number — frees the
+                  // row from a separate visual element.
+                  const utilColor =
+                    utilPct >= 95 ? 'text-red-500' : utilPct >= 80 ? 'text-amber-500' : 'text-[var(--text-muted)]';
+                  const statusBadge = m.isFrozen
+                    ? 'frozen'
+                    : !m.isActive
+                      ? 'inactive'
+                      : !m.borrowingEnabled
+                        ? 'supply only'
+                        : null;
+                  return (
+                    <tr key={`${m.protocol}-${m.chain}`} className="border-b border-[var(--border)]/50 last:border-0 hover:bg-[var(--text-faint)]/5">
+                      <td className="py-2 pl-4 sm:pl-2 align-top">
+                        <div className="inline-flex items-center gap-2 text-[var(--text)]">
+                          <ChainIcon chain={m.chain} size={22} />
+                          {chainLabel[m.chain]}
+                        </div>
+                        {statusBadge && (
+                          <div className="text-[10px] text-[var(--text-faint)]">{statusBadge}</div>
+                        )}
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums align-top">
+                        <div>{m.totalSuppliedUsd != null ? formatUSD(m.totalSuppliedUsd) : '—'}</div>
+                        {supplyCapPct != null && (
+                          <div className={`text-[10px] ${capColor(supplyCapPct)}`}>
+                            {supplyCapPct >= 100 ? 'at cap' : `${supplyCapPct.toFixed(0)}% of cap`}
+                          </div>
+                        )}
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums align-top">
+                        <div>{m.totalBorrowedUsd != null ? formatUSD(m.totalBorrowedUsd) : '—'}</div>
+                        {borrowCapPct != null && (
+                          <div className={`text-[10px] ${capColor(borrowCapPct)}`}>
+                            {borrowCapPct >= 100 ? 'at cap' : `${borrowCapPct.toFixed(0)}% of cap`}
+                          </div>
+                        )}
+                      </td>
+                      <td className="py-2 px-2 text-right tabular-nums align-top">
+                        {m.availableLiquidityUsd != null ? formatUSD(m.availableLiquidityUsd) : '—'}
+                      </td>
+                      <td className={`py-2 px-2 text-right tabular-nums align-top ${utilColor}`}>{utilPct.toFixed(1)}%</td>
+                      <td className="py-2 px-2 text-right tabular-nums align-top text-[var(--green)]">{supplyAprPct.toFixed(2)}%</td>
+                      <td className="py-2 px-2 text-right tabular-nums align-top">{borrowAprPct.toFixed(2)}%</td>
+                      <td className="py-2 px-2 text-right tabular-nums align-top">
+                        {m.liquidationThresholdBps != null ? `${(m.liquidationThresholdBps / 100).toFixed(0)}%` : '—'}
+                      </td>
+                      <td className="py-2 pr-4 sm:pr-2 text-right align-top">
+                        <a
+                          href={m.aaveMarketUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          title={`Open the ${symbol} reserve on Aave V3 (${chainLabel[m.chain]})`}
+                          className="inline-flex items-center gap-1.5 text-[var(--text-muted)] hover:text-[var(--accent)] whitespace-nowrap"
+                        >
+                          <ProtocolIcon slug="aave" size={18} />
+                          Open in Aave
+                          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                          </svg>
+                        </a>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="text-[10px] text-[var(--text-faint)] pt-1">
+            {symbol} is listed in {lending.markets.length} {lending.markets.length === 1 ? 'Aave V3 Core deployment' : 'Aave V3 Core deployments'}. Rates and balances reflect the latest block indexed by the source subgraph; USD figures use the live spot price from the detail header for consistent cross-chain aggregation.
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Markets({
+  markets,
+  chain,
+  summary,
+  onTradeClick,
+}: {
+  markets: TokenDetail['markets'];
+  chain: string;
+  summary: TokenDetail['summary'];
+  onTradeClick?: (e: TradeClickEvent) => void;
+}) {
   // Concentration risk signal: how much of the indexed pool TVL sits in the
   // single deepest pool. Markets are already TVL-sorted, so [0] is the
   // headliner. A 90%-concentration token is one rug-pull away from
@@ -195,7 +1046,17 @@ function Markets({ markets, chain, onTradeClick }: { markets: TokenDetail['marke
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between gap-2 flex-wrap">
-          <CardTitle>Markets</CardTitle>
+          <div className="flex items-center gap-3">
+            <TokenIcon
+              symbol={summary.symbol}
+              slug={summary.icon}
+              logoUri={summary.logoUri}
+              contract={summary.contract}
+              chain={summary.chain}
+              size={24}
+            />
+            <CardTitle>{summary.symbol} spot pools</CardTitle>
+          </div>
           <span className="text-[11px] text-[var(--text-faint)] flex items-center gap-2 flex-wrap">
             <span>{markets.length} pools · click to trade · <span className="italic">clicks tracked anonymously</span></span>
             {topShare != null && (
@@ -235,7 +1096,22 @@ function Markets({ markets, chain, onTradeClick }: { markets: TokenDetail['marke
         {markets.length === 0 ? (
           <div className="text-xs text-[var(--text-faint)]">No DEX pools indexed for this token.</div>
         ) : (
-          <table className="w-full text-sm">
+          <table className="w-full text-sm table-fixed">
+            <colgroup>
+              {/* Fixed-width layout so columns spread across the card's
+                  full width instead of all bunching to the left. The
+                  weighting roughly matches each column's likely content
+                  length: Venue/Pair carry icons + label, Fee is a tiny
+                  number, the USD columns are similar, Trade gets a
+                  generous slice so its left-aligned icons sit clearly
+                  apart from the numeric columns. */}
+              <col className="w-[18%]" />
+              <col className="w-[18%]" />
+              <col className="w-[8%]" />
+              <col className="w-[14%]" />
+              <col className="w-[14%]" />
+              <col className="w-[28%]" />
+            </colgroup>
             <thead>
               <tr className="border-b border-[var(--border)]">
                 <th className="py-2 text-left text-[11px] font-medium text-[var(--text-faint)]">Venue</th>
@@ -243,7 +1119,7 @@ function Markets({ markets, chain, onTradeClick }: { markets: TokenDetail['marke
                 <th className="py-2 text-right text-[11px] font-medium text-[var(--text-faint)]">Fee</th>
                 <th className="py-2 text-right text-[11px] font-medium text-[var(--text-faint)]">TVL</th>
                 <th className="py-2 text-right text-[11px] font-medium text-[var(--text-faint)]">24h Vol</th>
-                <th className="py-2 text-right text-[11px] font-medium text-[var(--text-faint)]">Trade</th>
+                <th className="py-2 pl-8 text-left text-[11px] font-medium text-[var(--text-faint)]">Trade</th>
               </tr>
             </thead>
             <tbody>
@@ -268,10 +1144,20 @@ function Markets({ markets, chain, onTradeClick }: { markets: TokenDetail['marke
                   : { className: 'border-b border-[var(--border)]/40' };
                 return (
                   <tr key={m.pool} {...rowProps}>
-                    <td className="py-2 capitalize">{m.protocol.replace(/_/g, ' ')}</td>
                     <td className="py-2">
-                      <span className="font-medium">{m.baseSymbol}</span>
-                      <span className="text-[var(--text-faint)]"> / {m.quoteSymbol}</span>
+                      <span className="inline-flex items-center gap-2 capitalize">
+                        <ProtocolIcon slug={defiLlamaSlugFor(m.protocol)} size={18} />
+                        {m.protocol.replace(/_/g, ' ')}
+                      </span>
+                    </td>
+                    <td className="py-2">
+                      <span className="inline-flex items-center gap-1.5">
+                        <TokenIcon symbol={m.baseSymbol} contract={m.baseContract} chain={summary.chain} size={18} />
+                        <span className="font-medium">{m.baseSymbol}</span>
+                        <span className="text-[var(--text-faint)]">/</span>
+                        <TokenIcon symbol={m.quoteSymbol} contract={m.quoteContract} chain={summary.chain} size={18} />
+                        <span className="text-[var(--text-faint)]">{m.quoteSymbol}</span>
+                      </span>
                     </td>
                     <td className="py-2 text-right tabular-nums text-[var(--text-muted)]">
                       {m.feeBps != null && m.feeBps > 0 ? `${(m.feeBps / 10000).toFixed(2)}%` : '—'}
@@ -282,9 +1168,10 @@ function Markets({ markets, chain, onTradeClick }: { markets: TokenDetail['marke
                     <td className="py-2 text-right tabular-nums text-[var(--text-muted)]">
                       {m.volume24hUsd != null ? formatUSD(m.volume24hUsd) : <span className="text-[var(--text-faint)]">—</span>}
                     </td>
-                    <td className="py-2 text-right">
+                    <td className="py-2 pl-8 text-left">
                       {trade ? (
-                        <span className="inline-flex items-center gap-1 text-xs text-[var(--accent)] hover:underline">
+                        <span className="inline-flex items-center gap-1.5 text-xs text-[var(--accent)] hover:underline">
+                          <ProtocolIcon slug={defiLlamaSlugFor(m.protocol) ?? defiLlamaSlugFor(trade.venue)} size={18} />
                           {trade.venue}
                           <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
@@ -315,7 +1202,14 @@ function relativeTime(ts: number): string {
   return `${Math.floor(diff / 86400)}d ago`;
 }
 
-function RecentSwaps({ swaps, symbol }: { swaps: TokenDetail['recentSwaps']; symbol: string }) {
+function RecentSwaps({
+  swaps,
+  summary,
+}: {
+  swaps: TokenDetail['recentSwaps'];
+  summary: TokenDetail['summary'];
+}) {
+  const symbol = summary.symbol;
   // "Last activity" indicator. A token whose most recent indexed swap was
   // hours/days ago is dormant — useful flag at a glance, no need to scan
   // the rows below to figure it out.
@@ -347,7 +1241,17 @@ function RecentSwaps({ swaps, symbol }: { swaps: TokenDetail['recentSwaps']; sym
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between gap-2 flex-wrap">
-          <CardTitle>Recent swaps</CardTitle>
+          <div className="flex items-center gap-3">
+            <TokenIcon
+              symbol={summary.symbol}
+              slug={summary.icon}
+              logoUri={summary.logoUri}
+              contract={summary.contract}
+              chain={summary.chain}
+              size={24}
+            />
+            <CardTitle>{symbol} recent swaps</CardTitle>
+          </div>
           <div className="text-[11px] text-[var(--text-faint)] flex items-center gap-3 flex-wrap">
             {buyPct != null && (
               <span title={`${buys} buys / ${sells} sells in the last ${swaps.length} indexed swaps. > 65% buys tinted green, < 35% tinted red.`}>
@@ -368,7 +1272,22 @@ function RecentSwaps({ swaps, symbol }: { swaps: TokenDetail['recentSwaps']; sym
         {swaps.length === 0 ? (
           <div className="text-xs text-[var(--text-faint)]">No recent swaps returned.</div>
         ) : (
-          <table className="w-full text-sm">
+          <table className="w-full text-sm table-fixed">
+            <colgroup>
+              {/* Fixed-width layout so columns spread across the card's
+                  full width. Pair gets the biggest share because it
+                  carries two icons + symbols + a protocol tag; Tx gets
+                  enough room for a fuller-than-6-char hash so the column
+                  doesn't read as a stub anchored to the right edge. */}
+              <col className="w-[9%]" />
+              <col className="w-[7%]" />
+              <col className="w-[11%]" />
+              <col className="w-[11%]" />
+              <col className="w-[11%]" />
+              <col className="w-[12%]" />
+              <col className="w-[24%]" />
+              <col className="w-[15%]" />
+            </colgroup>
             <thead>
               <tr className="border-b border-[var(--border)]">
                 <th className="py-2 text-left text-[11px] font-medium text-[var(--text-faint)]">When</th>
@@ -378,7 +1297,7 @@ function RecentSwaps({ swaps, symbol }: { swaps: TokenDetail['recentSwaps']; sym
                 <th className="py-2 text-right text-[11px] font-medium text-[var(--text-faint)]">Price</th>
                 <th className="py-2 text-left text-[11px] font-medium text-[var(--text-faint)] pl-3">Trader</th>
                 <th className="py-2 text-left text-[11px] font-medium text-[var(--text-faint)] pl-3">Pair</th>
-                <th className="py-2 text-right text-[11px] font-medium text-[var(--text-faint)]">Tx</th>
+                <th className="py-2 pl-3 text-left text-[11px] font-medium text-[var(--text-faint)]">Tx</th>
               </tr>
             </thead>
             <tbody>
@@ -419,17 +1338,24 @@ function RecentSwaps({ swaps, symbol }: { swaps: TokenDetail['recentSwaps']; sym
                     )}
                   </td>
                   <td className="py-2 pl-3 text-xs text-[var(--text-muted)]">
-                    {symbol} / {s.counterpartySymbol}
-                    <span className="ml-2 text-[10px] text-[var(--text-faint)] capitalize">{s.protocol.replace(/_/g, ' ')}</span>
+                    <span className="inline-flex items-center gap-1.5">
+                      <TokenIcon symbol={summary.symbol} slug={summary.icon} logoUri={summary.logoUri} contract={summary.contract} chain={summary.chain} size={16} />
+                      <span>{symbol}</span>
+                      <span className="text-[var(--text-faint)]">/</span>
+                      <TokenIcon symbol={s.counterpartySymbol} contract={s.counterpartyContract ?? undefined} chain={summary.chain} size={16} />
+                      <span>{s.counterpartySymbol}</span>
+                      <span className="ml-1 text-[10px] text-[var(--text-faint)] capitalize">{s.protocol.replace(/_/g, ' ')}</span>
+                    </span>
                   </td>
-                  <td className="py-2 text-right">
+                  <td className="py-2 pl-3 text-left">
                     <a
                       href={`https://etherscan.io/tx/${s.txHash}`}
                       target="_blank"
                       rel="noreferrer"
                       className="font-mono text-xs text-[var(--text-muted)] hover:text-[var(--accent)]"
+                      title={s.txHash}
                     >
-                      {s.txHash.slice(0, 6)}…
+                      {shortenAddress(s.txHash, 6)}
                     </a>
                   </td>
                 </tr>
@@ -478,6 +1404,7 @@ function TradeCTA({
       title={`Swap ${symbol} on ${trade.venue} (top pool by TVL)`}
       className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-[var(--accent)]/15 text-[var(--accent)] hover:bg-[var(--accent)]/25 transition-colors text-sm font-medium"
     >
+      <ProtocolIcon slug={defiLlamaSlugFor(top.protocol) ?? defiLlamaSlugFor(trade.venue)} size={18} />
       Trade on {trade.venue}
       <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
@@ -496,32 +1423,6 @@ const EXPLORERS: Record<string, { name: string; tx: string }> = {
   optimism: { name: 'Optimism', tx: 'https://optimistic.etherscan.io/token/' },
 };
 
-function CrossChainRow({ alt }: { alt: TokenDetail['summary']['altContracts'] }) {
-  const entries = Object.entries(alt).filter(([, addr]) => !!addr) as Array<[string, string]>;
-  if (entries.length === 0) return null;
-  return (
-    <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
-      <span className="text-[var(--text-faint)]">Also on:</span>
-      {entries.map(([chain, addr]) => {
-        const ex = EXPLORERS[chain];
-        if (!ex) return null;
-        return (
-          <a
-            key={chain}
-            href={`${ex.tx}${addr}`}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-[var(--border)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
-            title={`${ex.name}: ${addr}`}
-          >
-            {ex.name}
-          </a>
-        );
-      })}
-    </div>
-  );
-}
-
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   return (
@@ -538,87 +1439,6 @@ function CopyButton({ text }: { text: string }) {
     >
       {copied ? 'copied' : 'copy'}
     </button>
-  );
-}
-
-function Info({
-  contract,
-  decimals,
-  totalSupply,
-  circulating,
-  website,
-  name,
-}: {
-  contract: string;
-  decimals: number;
-  totalSupply: number | null;
-  circulating: number | null;
-  website: string | null;
-  name: string;
-}) {
-  let host: string | null = null;
-  if (website) {
-    try { host = new URL(website).host.replace(/^www\./, ''); } catch {}
-  }
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Info</CardTitle>
-      </CardHeader>
-      <CardContent>
-        {website && (
-          <a
-            href={website}
-            target="_blank"
-            rel="noreferrer"
-            className="flex items-center justify-between gap-2 mb-3 px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--bg-elevated)]/40 hover:border-[var(--accent)] hover:bg-[var(--accent)]/10 transition-colors group"
-          >
-            <span className="flex items-center gap-2">
-              <svg className="w-4 h-4 text-[var(--accent)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A9.005 9.005 0 0121 12.001c0 .921-.139 1.811-.398 2.65m-19.204-5.07A8.965 8.965 0 003 12.001c0 .921.139 1.811.398 2.65" />
-              </svg>
-              <span className="text-sm font-medium">Visit {name}</span>
-            </span>
-            <span className="flex items-center gap-1 text-[11px] text-[var(--text-faint)] group-hover:text-[var(--accent)]">
-              {host}
-              <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-              </svg>
-            </span>
-          </a>
-        )}
-        <dl className="space-y-2 text-sm">
-          <div className="flex items-center justify-between gap-3 flex-wrap">
-            <dt className="text-[var(--text-faint)] text-xs uppercase tracking-wider">Contract</dt>
-            <dd className="flex items-center font-mono text-xs">
-              <a
-                href={`https://etherscan.io/token/${contract}`}
-                target="_blank"
-                rel="noreferrer"
-                className="text-[var(--text-muted)] hover:text-[var(--accent)]"
-              >
-                {shortenAddress(contract, 6)}
-              </a>
-              <CopyButton text={contract} />
-            </dd>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <dt className="text-[var(--text-faint)] text-xs uppercase tracking-wider">Decimals</dt>
-            <dd className="tabular-nums">{decimals}</dd>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <dt className="text-[var(--text-faint)] text-xs uppercase tracking-wider">Circulating</dt>
-            <dd className="tabular-nums">{circulating != null ? formatNumber(Math.round(circulating)) : '—'}</dd>
-          </div>
-          {totalSupply != null && (
-            <div className="flex items-center justify-between gap-3">
-              <dt className="text-[var(--text-faint)] text-xs uppercase tracking-wider">Total Supply</dt>
-              <dd className="tabular-nums text-[var(--text-muted)]">{formatNumber(Math.round(totalSupply))}</dd>
-            </div>
-          )}
-        </dl>
-      </CardContent>
-    </Card>
   );
 }
 
@@ -640,10 +1460,12 @@ export default function TokenDetailPage({ params }: Props) {
       </div>
     );
 
-  const { summary, priceSeries, benchmarkSeries, topHolders, markets, recentSwaps, range24h } = data;
+  const { summary, priceSeries, benchmarkSeries, topHolders, markets, recentSwaps, range24h, lending, hyperliquid } = data;
 
   return (
-    <div className="px-4 sm:px-6 py-6 max-w-[1280px] mx-auto space-y-4">
+    <>
+      <StickyTokenBar summary={summary} />
+      <div className="px-4 sm:px-6 py-6 max-w-[1280px] mx-auto space-y-4">
       <div>
         <Link href="/tokens" className="text-xs text-[var(--text-muted)] hover:text-[var(--text)]">← Tokens</Link>
         <div className="mt-2 flex items-center gap-3 flex-wrap">
@@ -659,6 +1481,16 @@ export default function TokenDetailPage({ params }: Props) {
             {summary.name}
             <span className="ml-2 text-[var(--text-muted)]">{summary.symbol}</span>
           </h1>
+          {summary.tags.length > 0 && (
+            // Tags fold inline next to the symbol so they don't sit alone
+            // on a near-empty row when a token only has one tag (e.g. LINK
+            // → just "Oracle"). Reads as a category subtitle.
+            <span className="flex flex-wrap gap-1">
+              {summary.tags.map((tag) => (
+                <TagBadge key={tag} tag={tag} />
+              ))}
+            </span>
+          )}
           <a
             href={`https://etherscan.io/token/${summary.contract}`}
             target="_blank"
@@ -683,21 +1515,23 @@ export default function TokenDetailPage({ params }: Props) {
           )}
           <LiveQuoteIndicator asOf={summary.quoteAsOf} />
         </div>
-        {summary.tags.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1.5">
-            {summary.tags.map((tag) => (
-              <TagBadge key={tag} tag={tag} />
-            ))}
-          </div>
-        )}
-        <CrossChainRow alt={summary.altContracts} />
+
+        <HeaderInfoRow
+          contract={summary.contract}
+          decimals={summary.decimals}
+          website={summary.website}
+          name={summary.name}
+          alt={summary.altContracts}
+        />
 
         {summary.warnings.length > 0 && (
           <div className="mt-2 text-xs text-amber-500">⚠ {summary.warnings.join(' / ')}</div>
         )}
+
+        <SectionNav data={data} />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-4">
+      <div className="space-y-4">
         <div className="space-y-4">
           <PerformancePills
             summary={summary}
@@ -737,7 +1571,7 @@ export default function TokenDetailPage({ params }: Props) {
                 <span className="text-[10px] uppercase tracking-wider text-[var(--text-faint)]">24h DEX Vol</span>
                 <span
                   className="text-[10px] text-[var(--text-faint)] cursor-help"
-                  title="Latest-day decentralized-exchange volume aggregated across the Uniswap V2 + V3 mainnet subgraphs (and Uniswap V3 on Arbitrum / Base / Polygon when an alt-chain contract is configured), plus Curve Finance mainnet. CEX volume is intentionally excluded."
+                  title="Latest-day decentralized-exchange volume aggregated across Uniswap V2 + V3 mainnet, Uniswap V3 on Arbitrum / Base / Polygon (when an alt-chain contract is configured), PancakeSwap V3 mainnet, Aerodrome on Base, and Curve Finance mainnet. CEX volume is intentionally excluded."
                 >
                   ⓘ
                 </span>
@@ -799,83 +1633,131 @@ export default function TokenDetailPage({ params }: Props) {
             </Card>
           </div>
 
-          <TokenPriceChart
-            data={priceSeries}
-            benchmark={benchmarkSeries}
-            isLoading={isLoading && !data}
-            pegged={summary.tags.includes('Stablecoin')}
-            windowId={chartWindow}
-            onWindowChange={setChartWindow}
-          />
+          <div id="chart" className="scroll-mt-4">
+            <TokenPriceChart
+              data={priceSeries}
+              identity={{
+                symbol: summary.symbol,
+                icon: summary.icon,
+                logoUri: summary.logoUri,
+                contract: summary.contract,
+                chain: summary.chain,
+              }}
+              benchmark={benchmarkSeries}
+              isLoading={isLoading && !data}
+              pegged={summary.tags.includes('Stablecoin')}
+              windowId={chartWindow}
+              onWindowChange={setChartWindow}
+            />
+          </div>
 
-          <RecentSwaps swaps={recentSwaps} symbol={summary.symbol} />
+          <div id="swaps" className="scroll-mt-4">
+            <RecentSwaps swaps={recentSwaps} summary={summary} />
+          </div>
 
-          <Markets markets={markets} chain={summary.chain} onTradeClick={track} />
-        </div>
+          <div id="markets" className="scroll-mt-4">
+            <Markets markets={markets} chain={summary.chain} summary={summary} onTradeClick={track} />
+          </div>
 
-        <div className="space-y-4">
-          <Info
-            contract={summary.contract}
-            decimals={summary.decimals}
-            totalSupply={summary.totalSupply}
-            circulating={summary.circulatingSupply}
-            website={summary.website}
-            name={summary.name}
-          />
+          <div id="lending" className="scroll-mt-4">
+            <LendingCard lending={lending} summary={summary} />
+          </div>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Top holders</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {topHolders.length === 0 ? (
-                <div className="text-xs text-[var(--text-faint)]">No holder data returned.</div>
-              ) : (
-                <ol className="space-y-2 text-sm">
-                  {topHolders.slice(0, 10).map((h, i) => {
-                    // Share of circulating supply. The single most decision-
-                    // useful number on this list — without it the absolute
-                    // amounts are uninterpretable across tokens.
-                    const sharePct =
-                      summary.circulatingSupply != null && summary.circulatingSupply > 0
-                        ? (h.amount / summary.circulatingSupply) * 100
-                        : null;
-                    return (
-                      <li key={h.address} className="flex items-baseline justify-between gap-2">
-                        <span className="text-[var(--text-faint)] text-xs tabular-nums w-5 shrink-0">{i + 1}</span>
-                        <a
-                          href={`https://etherscan.io/address/${h.address}`}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="font-mono text-xs text-[var(--text-muted)] hover:text-[var(--accent)] flex-1 truncate"
-                        >
-                          {shortenAddress(h.address, 5)}
-                        </a>
-                        {h.isContract === true && (
-                          <span
-                            className="text-[9px] uppercase tracking-wider px-1 py-0.5 rounded bg-[var(--text-faint)]/10 text-[var(--text-faint)]"
-                            title="Address is a smart contract (bridge, staking module, LP pool, vesting, etc.)"
+          <div id="perps" className="scroll-mt-4">
+            <HyperliquidCard hyperliquid={hyperliquid} summary={summary} />
+          </div>
+
+          <div id="holders" className="scroll-mt-4">
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-3">
+                  <TokenIcon
+                    symbol={summary.symbol}
+                    slug={summary.icon}
+                    logoUri={summary.logoUri}
+                    contract={summary.contract}
+                    chain={summary.chain}
+                    size={24}
+                  />
+                  <CardTitle>{summary.symbol} top holders</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {topHolders.length === 0 ? (
+                  <div className="text-xs text-[var(--text-faint)]">No holder data returned.</div>
+                ) : (() => {
+                  // Compute each row's share once, then derive the max so the
+                  // inline scale-bar normalizes against the largest holder in
+                  // this list. Visual signal: how many ×s the #1 holder is
+                  // vs. the rest.
+                  const slice = topHolders.slice(0, 10);
+                  const shares = slice.map((h) =>
+                    summary.circulatingSupply != null && summary.circulatingSupply > 0
+                      ? (h.amount / summary.circulatingSupply) * 100
+                      : null
+                  );
+                  const maxShare = Math.max(0, ...shares.map((s) => s ?? 0));
+                  return (
+                    // Two-column wallet list on wide screens (was a single
+                    // narrow column when this card lived in a 320px sidebar).
+                    <ol className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-1.5 text-sm">
+                      {slice.map((h, i) => {
+                        const sharePct = shares[i];
+                        const relShare = sharePct != null && maxShare > 0 ? sharePct / maxShare : 0;
+                        return (
+                          <li
+                            key={h.address}
+                            className="flex items-center gap-2 py-1 border-b border-[var(--border)]/30 last:border-0"
                           >
-                            contract
-                          </span>
-                        )}
-                        {sharePct != null && (
-                          <span className="tabular-nums text-xs text-[var(--text)]">
-                            {sharePct >= 0.01 ? sharePct.toFixed(2) : sharePct.toFixed(3)}%
-                          </span>
-                        )}
-                        <span className="tabular-nums text-[10px] text-[var(--text-faint)]">
-                          {h.valueUsd != null ? formatUSD(h.valueUsd) : formatNumber(Math.round(h.amount))}
-                        </span>
-                      </li>
-                    );
-                  })}
-                </ol>
-              )}
-            </CardContent>
-          </Card>
+                            <span className="text-[var(--text-faint)] text-xs tabular-nums w-5 shrink-0">{i + 1}</span>
+                            <a
+                              href={`https://etherscan.io/address/${h.address}`}
+                              target="_blank"
+                              rel="noreferrer"
+                              title={h.address}
+                              className="font-mono text-xs text-[var(--text-muted)] hover:text-[var(--accent)] shrink-0"
+                            >
+                              {shortenAddress(h.address, 8)}
+                            </a>
+                            {h.isContract === true && (
+                              <span
+                                className="text-[9px] uppercase tracking-wider px-1 py-0.5 rounded bg-[var(--text-faint)]/10 text-[var(--text-faint)] shrink-0"
+                                title="Address is a smart contract (bridge, staking module, LP pool, vesting, etc.)"
+                              >
+                                contract
+                              </span>
+                            )}
+                            {/* Inline scale bar — fills proportional to this
+                               holder's share vs the largest in the list.
+                               Sits in the flexible space between the address
+                               and the numerical readout so the visual rank
+                               reads at a glance. */}
+                            <div className="flex-1 min-w-[40px] h-1 rounded-full bg-[var(--text-faint)]/15 overflow-hidden">
+                              <div
+                                className={`h-full ${i === 0 ? 'bg-[var(--accent)]' : 'bg-[var(--accent)]/60'}`}
+                                style={{ width: `${(relShare * 100).toFixed(2)}%` }}
+                              />
+                            </div>
+                            {sharePct != null && (
+                              <span className="tabular-nums text-xs text-[var(--text)] shrink-0 w-12 text-right">
+                                {sharePct >= 0.01 ? sharePct.toFixed(2) : sharePct.toFixed(3)}%
+                              </span>
+                            )}
+                            <span className="tabular-nums text-[10px] text-[var(--text-faint)] shrink-0 w-16 text-right">
+                              {h.valueUsd != null ? formatUSD(h.valueUsd) : formatNumber(Math.round(h.amount))}
+                            </span>
+                          </li>
+                        );
+                      })}
+                    </ol>
+                  );
+                })()}
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/src/app/tokens/page.tsx
+++ b/src/app/tokens/page.tsx
@@ -10,7 +10,7 @@ import { useTokenDirectory } from '@/hooks/useTokens';
 import { formatNumber, formatPrice, formatUSD } from '@/lib/utils';
 import type { TokenSummary } from '@/lib/tokens/types';
 
-type SortKey = 'mcap' | 'price' | 'change' | 'change7d' | 'change30d' | 'change90d' | 'holders' | 'symbol' | 'concentration' | 'eoaConcentration' | 'volume';
+type SortKey = 'mcap' | 'price' | 'change' | 'change7d' | 'change30d' | 'holders' | 'symbol' | 'concentration' | 'volume' | 'hlOi';
 type SortDir = 'asc' | 'desc';
 
 
@@ -43,11 +43,10 @@ const COMPARATORS: Record<SortKey, (a: TokenSummary, b: TokenSummary) => number>
   change: (a, b) => (b.change24hPct ?? 0) - (a.change24hPct ?? 0),
   change7d: (a, b) => (b.change7dPct ?? 0) - (a.change7dPct ?? 0),
   change30d: (a, b) => (b.change30dPct ?? 0) - (a.change30dPct ?? 0),
-  change90d: (a, b) => (b.change90dPct ?? 0) - (a.change90dPct ?? 0),
   holders: (a, b) => (b.holders ?? 0) - (a.holders ?? 0),
   concentration: (a, b) => (b.top10Share ?? 0) - (a.top10Share ?? 0),
-  eoaConcentration: (a, b) => (b.top10EoaShare ?? 0) - (a.top10EoaShare ?? 0),
   volume: (a, b) => (b.dexVolume24hUsd ?? 0) - (a.dexVolume24hUsd ?? 0),
+  hlOi: (a, b) => (b.hyperliquidOiUsd ?? 0) - (a.hyperliquidOiUsd ?? 0),
   symbol: (a, b) => a.symbol.localeCompare(b.symbol),
 };
 
@@ -74,28 +73,110 @@ function VolumeCell({ total, byVenue }: { total: number | null; byVenue: Record<
   );
 }
 
-function ConcentrationCell({
+// Holders cell with a hover popover that surfaces the top-10 EOA
+// concentration we used to dedicate a column to. Replaces the standalone
+// ConcentrationCell now that we've reclaimed its slot for HL OI.
+function HoldersCell({
+  count,
   eoaShare,
   contractShare,
 }: {
+  count: number | null;
   eoaShare: number | null;
   contractShare: number | null;
 }) {
-  if (eoaShare == null && contractShare == null) {
-    return <span className="text-[var(--text-faint)]">—</span>;
-  }
+  if (count == null) return <span className="text-[var(--text-faint)]">—</span>;
+  const hasConcentration = eoaShare != null || contractShare != null;
   const eoaPct = (eoaShare ?? 0) * 100;
   const contractPct = (contractShare ?? 0) * 100;
-  const color =
-    eoaPct >= 60 ? 'text-red-500' : eoaPct >= 30 ? 'text-amber-500' : 'text-[var(--text-muted)]';
+  const eoaColor =
+    eoaPct >= 60 ? 'text-red-500' : eoaPct >= 30 ? 'text-amber-500' : 'text-[var(--text)]';
   return (
-    <span className="inline-flex flex-col items-end leading-tight">
-      <span className={color}>{eoaPct.toFixed(1)}%</span>
-      {contractPct >= 0.1 && (
-        <span className="text-[10px] text-[var(--text-faint)]">
-          +{contractPct.toFixed(1)}% contracts
+    <span className="relative inline-flex group">
+      <span className={hasConcentration ? 'cursor-help underline decoration-dotted decoration-[var(--text-faint)] underline-offset-2' : ''}>
+        {formatNumber(count)}
+      </span>
+      {hasConcentration && (
+        <span className="invisible group-hover:visible absolute right-0 top-5 z-30 w-56 rounded border border-[var(--border)] bg-[var(--bg-elevated)] p-2 text-[11px] text-[var(--text-muted)] shadow-lg pointer-events-none text-left">
+          <span className="block font-semibold text-[var(--text)] mb-1">Top-10 holder concentration</span>
+          <span className="flex items-center justify-between gap-2 mt-0.5 tabular-nums">
+            <span>EOA share</span>
+            <span className={eoaColor}>{eoaPct.toFixed(1)}%</span>
+          </span>
+          {contractPct >= 0.01 && (
+            <span className="flex items-center justify-between gap-2 mt-0.5 tabular-nums">
+              <span>Contract share</span>
+              <span className="text-[var(--text)]">{contractPct.toFixed(1)}%</span>
+            </span>
+          )}
+          <span className="block mt-2 text-[10px] text-[var(--text-faint)]">
+            Higher EOA % means a few wallets dominate circulating supply. Contract
+            holders (bridges, staking, LP) are split out via on-chain eth_getCode.
+          </span>
         </span>
       )}
+    </span>
+  );
+}
+
+// Cell for the new "HL OI" column. Renders a sortable USD figure plus a
+// tiny inline funding-direction marker. Empty for tokens without an HL
+// perp listing — that's most of the catalog.
+function HlOiCell({
+  oiUsd,
+  fundingHourly,
+  coin,
+}: {
+  oiUsd: number | null;
+  fundingHourly: number | null;
+  coin: string | null;
+}) {
+  // Distinguish "no perp market on HL" from "data failed to load". A bare
+  // dash reads as the latter; explicit "not listed" copy with a faint
+  // italic style signals "this token doesn't trade as a perp on HL"
+  // without implying a fetch failure.
+  if (oiUsd == null) {
+    return (
+      <span
+        className="text-[var(--text-faint)] italic text-[10px] font-normal"
+        title="No Hyperliquid perp market for this token"
+      >
+        not listed
+      </span>
+    );
+  }
+  // Direction marker: ↑ when long-pay funding (longs paying shorts to hold,
+  // i.e. long-biased venue), ↓ when short-pay, • when at HL's baseline
+  // floor (no directional skew).
+  const HL_BASELINE = 1.25e-5;
+  const atFloor =
+    fundingHourly != null &&
+    Math.abs(Math.abs(fundingHourly) - HL_BASELINE) < HL_BASELINE * 0.05;
+  const arrow =
+    fundingHourly == null
+      ? null
+      : atFloor
+        ? { glyph: '·', cls: 'text-[var(--text-faint)]', label: 'baseline' }
+        : fundingHourly > 0
+          ? { glyph: '↑', cls: 'text-[var(--green)]', label: 'long-pay funding' }
+          : { glyph: '↓', cls: 'text-red-500', label: 'short-pay funding' };
+  return (
+    <span className="inline-flex items-baseline gap-1 tabular-nums" title={coin ? `${coin} on Hyperliquid` : undefined}>
+      <span>{formatUSD(oiUsd)}</span>
+      {arrow && <span className={`text-[10px] ${arrow.cls}`} title={arrow.label}>{arrow.glyph}</span>}
+    </span>
+  );
+}
+
+// Small "Perps" pill rendered next to the token tags when an HL perp
+// market exists for this seed. Cheap visual signal at the catalog level.
+function PerpsBadge({ coin }: { coin: string }) {
+  return (
+    <span
+      title={`${coin} has a Hyperliquid perp market — click into the detail page for OI, funding, liquidations, and positioning.`}
+      className="inline-flex items-center text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent)]/15 text-[var(--accent)] border border-[var(--accent)]/30"
+    >
+      Perps
     </span>
   );
 }
@@ -210,12 +291,11 @@ export default function TokensPage() {
                   {header('24h %', 'change')}
                   {header('7d %', 'change7d')}
                   {header('30d %', 'change30d')}
-                  {header('90d %', 'change90d')}
                   <th className="py-2 text-right text-[11px] font-medium text-[var(--text-faint)] pl-4">30d</th>
                   {header('DEX Vol', 'volume', 'right', 'Latest day’s volume aggregated across the Uniswap V2 + V3 mainnet subgraphs. Hover any value for the per-venue breakdown.')}
                   {header('Mcap', 'mcap')}
-                  {header('Holders', 'holders')}
-                  {header('Top 10 EOA', 'eoaConcentration', 'right', 'Share of circulating supply held by the 10 largest externally-owned accounts (likely-human wallets). Smart contract holders (bridges, staking modules, LP pools, vesting) are split out below the headline number. Contract status detected via on-chain eth_getCode; cached.', 'pl-4')}
+                  {header('Holders', 'holders', 'right', 'Token API holder count. Hover the value to see top-10 holder concentration split into EOA vs contract share — a higher EOA share is a tighter wallet distribution.')}
+                  {header('HL OI', 'hlOi', 'right', 'Hyperliquid open interest in USD. ↑ = long-pay funding (longs paying shorts to hold). ↓ = short-pay funding. · = at HL\'s per-asset baseline (no directional skew). Click any row to drill into the perps card on the detail page.', 'pl-4')}
                 </tr>
               </thead>
               <tbody>
@@ -232,6 +312,7 @@ export default function TokensPage() {
                         {t.tags.map((tag) => (
                           <TagBadge key={tag} tag={tag} />
                         ))}
+                        {t.hyperliquidCoin && <PerpsBadge coin={t.hyperliquidCoin} />}
                         {t.website && (
                           <a
                             href={t.website}
@@ -255,7 +336,6 @@ export default function TokensPage() {
                     <td className="py-2 text-right tabular-nums"><PctBadge value={t.change24hPct} /></td>
                     <td className="py-2 text-right tabular-nums"><PctBadge value={t.change7dPct} /></td>
                     <td className="py-2 text-right tabular-nums"><PctBadge value={t.change30dPct} /></td>
-                    <td className="py-2 text-right tabular-nums"><PctBadge value={t.change90dPct} /></td>
                     <td className="py-2 text-right pl-4">
                       <div className="inline-flex justify-end"><Sparkline points={t.sparkline} id={t.contract.slice(2, 10)} /></div>
                     </td>
@@ -266,16 +346,16 @@ export default function TokensPage() {
                       {t.marketCapUsd != null ? formatUSD(t.marketCapUsd) : '—'}
                     </td>
                     <td className="py-2 text-right tabular-nums">
-                      {t.holders != null ? formatNumber(t.holders) : '—'}
+                      <HoldersCell count={t.holders} eoaShare={t.top10EoaShare} contractShare={t.top10ContractShare} />
                     </td>
                     <td className="py-2 text-right tabular-nums pl-4 pr-2">
-                      <ConcentrationCell eoaShare={t.top10EoaShare} contractShare={t.top10ContractShare} />
+                      <HlOiCell oiUsd={t.hyperliquidOiUsd} fundingHourly={t.hyperliquidFundingHourly} coin={t.hyperliquidCoin} />
                     </td>
                   </tr>
                 ))}
                 {rows.length === 0 && data.length > 0 && (
                   <tr>
-                    <td colSpan={12} className="py-6 text-center text-sm text-[var(--text-faint)]">No tokens match &quot;{query}&quot;.</td>
+                    <td colSpan={11} className="py-6 text-center text-sm text-[var(--text-faint)]">No tokens match &quot;{query}&quot;.</td>
                   </tr>
                 )}
               </tbody>

--- a/src/components/charts/TokenPriceChart.tsx
+++ b/src/components/charts/TokenPriceChart.tsx
@@ -13,11 +13,21 @@ import {
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { ChartSkeleton } from '@/components/ui/ChartSkeleton';
+import { TokenIcon } from '@/components/tokens/TokenIcon';
 import { formatCompact, formatUSD } from '@/lib/utils';
 import type { OhlcPoint } from '@/lib/tokens/types';
 
 interface Props {
   data: OhlcPoint[];
+  /** Token identity for the card header. When omitted, the header
+   *  falls back to a generic "Price" title without a logo. */
+  identity?: {
+    symbol: string;
+    icon: string | null;
+    logoUri: string | null;
+    contract: string;
+    chain: 'mainnet' | 'arbitrum' | 'base' | 'polygon' | 'optimism';
+  };
   /**
    * Optional ETH/USD daily closes used as a volatility benchmark. When the
    * data is provided, the chart's stats line shows e.g. "vol 47% (1.8× ETH)"
@@ -125,6 +135,7 @@ function Candle({ x = 0, y = 0, width = 0, height = 0, payload }: CandleProps) {
 
 export function TokenPriceChart({
   data,
+  identity,
   benchmark,
   isLoading,
   pegged = false,
@@ -218,8 +229,18 @@ export function TokenPriceChart({
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between gap-3 flex-wrap">
-          <div className="flex items-baseline gap-3">
-            <CardTitle>Price</CardTitle>
+          <div className="flex items-center gap-3 flex-wrap">
+            {identity && (
+              <TokenIcon
+                symbol={identity.symbol}
+                slug={identity.icon}
+                logoUri={identity.logoUri}
+                contract={identity.contract}
+                chain={identity.chain}
+                size={24}
+              />
+            )}
+            <CardTitle>{identity ? `${identity.symbol} price` : 'Price'}</CardTitle>
             {stats && (
               <span className={`text-xs tabular-nums ${positive ? 'text-[var(--green)]' : 'text-red-500'}`}>
                 {positive ? '+' : ''}{stats.pct.toFixed(2)}%

--- a/src/components/tokens/ChainIcon.tsx
+++ b/src/components/tokens/ChainIcon.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+/**
+ * Tiny chain logo for places where we mention the chain a row's data
+ * lives on (e.g. cross-chain Aave V3 markets table). Pulls from web3icons
+ * via jsdelivr — same CDN we use for token icons, so no new dependency.
+ */
+type ChainKey = 'mainnet' | 'arbitrum' | 'base' | 'polygon' | 'optimism';
+
+const SLUG: Record<ChainKey, string> = {
+  mainnet: 'ethereum',
+  arbitrum: 'arbitrum-one',
+  base: 'base',
+  polygon: 'polygon',
+  optimism: 'optimism',
+};
+
+interface Props {
+  chain: ChainKey;
+  size?: number;
+  className?: string;
+}
+
+export function ChainIcon({ chain, size = 14, className = '' }: Props) {
+  const slug = SLUG[chain];
+  if (!slug) return null;
+  // White backplate keeps dark glyphs (Ethereum diamond, Arbitrum mark)
+  // visible on the page's purple-tinted dark background. The inner glyph
+  // is held to ~70% of the circle so square logos (Base, Optimism wordmark)
+  // don't kiss the white edge — they were designed full-bleed and need
+  // their own padding.
+  const inner = Math.round(size * 0.7);
+  return (
+    <span
+      className={`inline-flex items-center justify-center rounded-full bg-white shrink-0 ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <img
+        src={`https://cdn.jsdelivr.net/gh/0xa3k5/web3icons@main/raw-svgs/networks/branded/${slug}.svg`}
+        alt=""
+        width={inner}
+        height={inner}
+        loading="lazy"
+      />
+    </span>
+  );
+}

--- a/src/components/tokens/ProtocolIcon.tsx
+++ b/src/components/tokens/ProtocolIcon.tsx
@@ -1,0 +1,99 @@
+/**
+ * Small protocol logo for CTAs that send users off-site (Aave, Uniswap,
+ * Kyber, Hyperliquid, etc).
+ *
+ * Renders every protocol as a rounded-square tile of identical outer
+ * dimensions so logos line up vertically when stacked in a column (e.g.
+ * the Trade column of the Spot Pools table). Sources:
+ *   - Aave / Uniswap: web3icons brand SVG (matches the AAVE / UNI token
+ *     icon used on the directory) on a white tile so the glyph stays
+ *     visible against the page's dark background.
+ *   - Everyone else: DefiLlama's protocol icon CDN, which already returns
+ *     full-bleed colored tiles.
+ */
+'use client';
+
+interface Props {
+  slug: string | null | undefined;
+  size?: number;
+  className?: string;
+}
+
+// web3icons SVG slugs for protocols whose governance token is also a seed
+// in our directory — reusing the same asset keeps the protocol logo on
+// the detail page identical to the token icon shown on the index.
+const TOKEN_PROXY_SLUG: Record<string, string> = {
+  uniswap: 'UNI',
+  aave: 'AAVE',
+};
+
+export function ProtocolIcon({ slug, size = 14, className = '' }: Props) {
+  if (!slug) return null;
+  const baseSlug = slug.startsWith('aave-') ? 'aave' : slug.startsWith('uniswap-') ? 'uniswap' : slug;
+  const proxyToken = TOKEN_PROXY_SLUG[baseSlug];
+
+  const tileClass = `inline-flex items-center justify-center rounded-md overflow-hidden shrink-0 ${className}`;
+  const boxStyle = { width: size, height: size } as const;
+
+  if (proxyToken) {
+    // White backplate so dark glyphs (Aave dome+eyes, Uniswap unicorn)
+    // read against the page's dark surface. Inner img held to ~80% of
+    // the tile so the brand mark doesn't kiss the rounded edge.
+    const inner = Math.round(size * 0.8);
+    return (
+      <span className={`${tileClass} bg-white`} style={boxStyle}>
+        <img
+          src={`https://cdn.jsdelivr.net/gh/0xa3k5/web3icons@main/raw-svgs/tokens/branded/${proxyToken}.svg`}
+          alt=""
+          width={inner}
+          height={inner}
+          loading="lazy"
+        />
+      </span>
+    );
+  }
+
+  // DefiLlama icons are already full-bleed colored tiles — no backplate
+  // needed, just render the img directly inside the same outer box.
+  const px = size * 2;
+  return (
+    <span className={tileClass} style={boxStyle}>
+      <img
+        src={`https://icons.llamao.fi/icons/protocols/${slug}?w=${px}&h=${px}`}
+        alt=""
+        width={size}
+        height={size}
+        loading="lazy"
+      />
+    </span>
+  );
+}
+
+/**
+ * Best-effort mapping from a free-form protocol name (Token API's
+ * `pool.protocol` string) or a venue host (`trade.venue` from
+ * `getTradeUrl`) to the DefiLlama icon slug for that protocol.
+ *
+ * The mapping is intentionally lenient — the same logo represents
+ * Uniswap V2 / V3 / V4, Aave V2 / V3, etc., so we don't try to be
+ * version-precise unless DefiLlama distinguishes them and the difference
+ * matters visually.
+ */
+export function defiLlamaSlugFor(idOrVenue: string | null | undefined): string | null {
+  if (!idOrVenue) return null;
+  const s = idOrVenue.toLowerCase();
+  if (s.includes('uniswap')) return 'uniswap';
+  if (s.includes('sushi')) return 'sushiswap';
+  if (s.includes('pancake')) return 'pancakeswap';
+  if (s.includes('curve')) return 'curve-finance';
+  if (s.includes('balancer')) return 'balancer-v2';
+  if (s.includes('aave')) return 'aave';
+  if (s.includes('kyber')) return 'kyberswap';
+  if (s.includes('cow')) return 'cowswap';
+  if (s.includes('aerodrome') || s.includes('velodrome')) return 'aerodrome-v1';
+  if (s.includes('dodo')) return 'dodo';
+  if (s.includes('bancor')) return 'bancor';
+  if (s.includes('hyperliquid')) return 'hyperliquid';
+  if (s.includes('1inch')) return '1inch-network';
+  return null;
+}

--- a/src/components/tokens/TokenIcon.tsx
+++ b/src/components/tokens/TokenIcon.tsx
@@ -23,6 +23,10 @@ interface Props {
   chain?: 'mainnet' | 'arbitrum' | 'base' | 'polygon' | 'optimism';
   size?: number;
   className?: string;
+  /** Override the circle's background. Used when rendering as a protocol icon
+   *  on top of a dark page background — passing `#fff` keeps dark glyphs
+   *  (Aave dome, Uniswap shield) visible. Defaults to var(--bg-elevated). */
+  bg?: string;
 }
 
 const TRUSTWALLET_CHAIN: Record<string, string> = {
@@ -31,6 +35,16 @@ const TRUSTWALLET_CHAIN: Record<string, string> = {
   base: 'base',
   polygon: 'polygon',
   optimism: 'optimism',
+};
+
+// EVM chain IDs for the CDNs that key by numeric chain (DefiLlama, 1inch).
+// Keep this aligned with TRUSTWALLET_CHAIN above.
+const CHAIN_ID: Record<string, number> = {
+  mainnet: 1,
+  arbitrum: 42161,
+  base: 8453,
+  polygon: 137,
+  optimism: 10,
 };
 
 const FALLBACK_PALETTE = [
@@ -62,27 +76,44 @@ function buildSourceChain(
     out.push(`https://cdn.jsdelivr.net/gh/0xa3k5/web3icons@main/raw-svgs/tokens/branded/${slug.toUpperCase()}.svg`);
   }
   if (contract) {
+    const lower = contract.toLowerCase();
     try {
       const checksum = getAddress(contract);
       const tw = TRUSTWALLET_CHAIN[chain ?? 'mainnet'] ?? 'ethereum';
       out.push(`https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${tw}/assets/${checksum}/logo.png`);
     } catch {}
+    // DefiLlama's token-icons CDN keys by chain-id + lowercase address. Has
+    // very wide coverage of tradable ERC-20s — useful as a fallback for
+    // counterparty tokens we encounter via Recent Swaps but don't carry
+    // in our 154-token seed set.
+    const chainId = CHAIN_ID[chain ?? 'mainnet'];
+    if (chainId) {
+      out.push(`https://token-icons.llamao.fi/icons/tokens/${chainId}/${lower}?h=64`);
+    }
+    // 1inch's CDN — mainnet-only but extensive. Last resort before falling
+    // back to the deterministic gradient initials.
+    if ((chain ?? 'mainnet') === 'mainnet') {
+      out.push(`https://tokens-data.1inch.io/images/${lower}.png`);
+    }
   }
   return out;
 }
 
-export function TokenIcon({ symbol, contract, logoUri, slug, chain = 'mainnet', size = 28, className }: Props) {
+export function TokenIcon({ symbol, contract, logoUri, slug, chain = 'mainnet', size = 28, className, bg: bgOverride }: Props) {
   const sources = useMemo(() => buildSourceChain(logoUri, slug, contract, chain), [logoUri, slug, contract, chain]);
   const [sourceIdx, setSourceIdx] = useState(0);
   const exhausted = sourceIdx >= sources.length;
 
   const [bg, fg] = FALLBACK_PALETTE[symbolHash(symbol) % FALLBACK_PALETTE.length];
   const initials = symbol.replace(/[^A-Za-z0-9]/g, '').slice(0, 3).toUpperCase();
+  const background = exhausted
+    ? `linear-gradient(135deg, ${bg}, ${fg})`
+    : bgOverride ?? 'var(--bg-elevated)';
 
   return (
     <div
       className={`relative rounded-full overflow-hidden border-[0.5px] border-[var(--border)] flex items-center justify-center shrink-0 ${className ?? ''}`}
-      style={{ width: size, height: size, background: exhausted ? `linear-gradient(135deg, ${bg}, ${fg})` : 'var(--bg-elevated)' }}
+      style={{ width: size, height: size, background }}
     >
       {exhausted ? (
         <span

--- a/src/lib/tokens/BACKLOG.md
+++ b/src/lib/tokens/BACKLOG.md
@@ -4,13 +4,15 @@ Captured 2026-05-07. Sized roughly; "lift" is engineering effort, not value.
 
 ## Higher lift (multi-hour)
 
-### Lending-market cross-section (Aave / Compound / Morpho)
-- For tokens accepted as collateral, surface "supplied: $X / borrowed: $Y
-  / utilization Z%" on the detail page. Differentiated vs CoinGecko/CMC
-  because they don't have indexer access.
-- We have the `mcp__graph-aave` and `mcp__graph-lending` subgraph queries
-  at our disposal. New file `src/lib/tokens/lending.ts` that aggregates
-  supply/borrow snapshots per token contract.
+### Lending-market expansion (Compound / Morpho / Spark)
+- Aave V3 mainnet shipped 2026-05-08 (`src/lib/tokens/lending.ts` +
+  `LendingCard` on detail page; 35 of our seed tokens light up).
+- Compound V3 (cUSDCv3, cWETHv3, cUSDTv3) and Morpho Blue both have
+  per-market schemas; add as additional `markets[]` entries with the
+  same shape so the existing card renders multi-protocol breakdowns
+  without a redesign. Spark (forked Aave V3) shares the schema.
+- Future: cross-chain Aave V3 (Arbitrum, Base, Polygon, Optimism)
+  using `altContracts` from the seed and per-chain subgraph IDs.
 
 ### Price-impact estimate via V3 ticks
 - "$10K moves price 0.2% on top pool" — separates real liquidity from
@@ -37,5 +39,14 @@ Captured 2026-05-07. Sized roughly; "lift" is engineering effort, not value.
 - Quick-win items #1–#5 shipped 2026-05-07.
 - Medium-lift items #6 (volume strip), #7 (vol vs ETH benchmark),
   #8 (cross-pool spread) shipped 2026-05-07.
+- 2026-05-08: PancakeSwap V3 mainnet + Aerodrome Base added to DEX
+  volume aggregator (~+$386M total daily volume captured); Aave V3
+  mainnet lending card shipped on detail page.
+- 2026-05-08 (later): Aave V3 lending expanded to all 5 Graph-Network
+  deployments (mainnet + Arbitrum + Base + Polygon + Optimism); 17 seeds
+  patched with missing `altContracts` to unlock L2 lending coverage;
+  Hyperliquid perps card added on detail page (Pinax Token API
+  `/v1/hyperliquid/*`, surfacing OI / 24h volume / annualized funding /
+  daily liquidations split by long/short).
 - Remaining items below are real builds. Skip unless there's user demand
   beyond exploration; the page is already information-dense.

--- a/src/lib/tokens/api.ts
+++ b/src/lib/tokens/api.ts
@@ -55,7 +55,16 @@ async function acquireRateSlot(): Promise<void> {
   }
 }
 
-async function get<T>(path: string, params: Record<string, string | number>): Promise<ApiEnvelope<T>> {
+/**
+ * Shared low-level Token API GET. Exported so adjacent modules
+ * (e.g. `hyperliquid.ts`) can hit `/v1/*` paths through the same auth +
+ * rate-limit + 5xx/429 retry path used everywhere else. Path is the
+ * leading-slash route (`/v1/...`); params become the query string.
+ */
+export async function tokenApiGet<T>(
+  path: string,
+  params: Record<string, string | number>
+): Promise<ApiEnvelope<T>> {
   const qs = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) qs.set(k, String(v));
   const url = `${BASE_URL}${path}?${qs}`;
@@ -126,7 +135,7 @@ export async function fetchTokenMetadata(
   network: string,
   contract: string
 ): Promise<ApiTokenMetadata | null> {
-  const env = await get<ApiTokenMetadata>('/v1/evm/tokens', { network, contract });
+  const env = await tokenApiGet<ApiTokenMetadata>('/v1/evm/tokens', { network, contract });
   const t = env.data?.[0];
   if (!t) {
     recordDeficiency('TOKEN_API_TOKENS_EMPTY', `tokens endpoint returned 0 rows for ${network}/${contract}`);
@@ -158,7 +167,7 @@ export async function fetchPoolOhlc(
 ): Promise<ApiOhlcPoint[]> {
   const params: Record<string, string | number> = { network, pool, interval, limit };
   if (page > 1) params.page = page;
-  const env = await get<ApiOhlcPoint>('/v1/evm/pools/ohlc', params);
+  const env = await tokenApiGet<ApiOhlcPoint>('/v1/evm/pools/ohlc', params);
   // The API returns duplicate rows per datetime in some pools (observed on
   // CoW settlement and on shared Uniswap V3 pools). De-dupe by datetime,
   // keeping the row with the most transactions (likeliest the real bar).
@@ -181,7 +190,7 @@ export async function fetchHolders(
   contract: string,
   limit = 10
 ): Promise<ApiHolder[]> {
-  const env = await get<ApiHolder>('/v1/evm/holders', { network, contract, limit });
+  const env = await tokenApiGet<ApiHolder>('/v1/evm/holders', { network, contract, limit });
   return env.data ?? [];
 }
 
@@ -200,7 +209,7 @@ export async function fetchPoolsForToken(
   contract: string,
   limit = 25
 ): Promise<ApiPool[]> {
-  const env = await get<ApiPool>('/v1/evm/pools', { network, input_token: contract, limit });
+  const env = await tokenApiGet<ApiPool>('/v1/evm/pools', { network, input_token: contract, limit });
   return env.data ?? [];
 }
 
@@ -230,8 +239,8 @@ export async function fetchSwapsForToken(
   // The API has no OR filter, so we issue two calls in parallel and merge.
   // Tracked: TOKEN_API_NO_OR_FILTER (recorded in fetcher when both succeed).
   const [asInput, asOutput] = await Promise.all([
-    get<ApiSwap>('/v1/evm/swaps', { network, input_contract: contract, limit }),
-    get<ApiSwap>('/v1/evm/swaps', { network, output_contract: contract, limit }),
+    tokenApiGet<ApiSwap>('/v1/evm/swaps', { network, input_contract: contract, limit }),
+    tokenApiGet<ApiSwap>('/v1/evm/swaps', { network, output_contract: contract, limit }),
   ]);
   const all = [...(asInput.data ?? []), ...(asOutput.data ?? [])];
   all.sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0));

--- a/src/lib/tokens/dex-volume.ts
+++ b/src/lib/tokens/dex-volume.ts
@@ -1,21 +1,24 @@
 /**
- * DEX volume aggregation across native Uniswap V2 + V3 deployments on
- * The Graph Network (Arbitrum gateway). One batched query per subgraph
+ * DEX volume aggregation across native Uniswap V2 + V3 + V3-fork deployments
+ * on The Graph Network (Arbitrum gateway). One batched query per subgraph
  * for all seeds at once, so cost is O(subgraphs) not O(seeds).
  *
  * Coverage today:
  *   - Uniswap V3 mainnet, V2 mainnet (subgraph IDs)
  *   - Uniswap V3 Arbitrum, Base, Polygon (deployment IPFS hashes)
+ *   - PancakeSwap V3 mainnet (V3-schema-compatible)
+ *   - Aerodrome Base (V3-schema-compatible)
+ *   - Curve mainnet (Messari schema, pool-walk)
+ *
+ * Deferred: SushiSwap and Balancer mainnet — Sushi's current published
+ * subgraph IDs on the Graph Network aren't ones I could verify under the
+ * gateway, and Balancer's `TokenSnapshot` exposes only cumulative volume
+ * (would need a two-snapshot delta to derive 24h). Both warrant a separate
+ * iteration.
  *
  * Why subgraph queries instead of Token API: Token API has no per-token
  * aggregate volume, only per-pool OHLC. Tracked as deficiency
  * `TOKEN_API_NO_TOKEN_LEVEL_VOLUME`.
- *
- * Schemas: native Uniswap V3 exposes `Token.volumeUSD` + `tokenDayData`.
- * Uniswap V2 exposes `tradeVolumeUSD` + `tokenDayData.dailyVolumeUSD`.
- * Sushi/Curve/Balancer all use the Messari standardized schema which has
- * no per-token day volume; aggregating volume there requires walking pool
- * entities and is deferred to a follow-on iteration.
  */
 
 import type { TokenSeed } from './types';
@@ -93,6 +96,21 @@ const SPECS: SubgraphSpec[] = [
     venue: 'Uniswap V3',
     chain: 'polygon',
     endpoint: { kind: 'deployment', hash: 'QmdAaDAUDCypVB85eFUkQMkS5DE1HV4s7WJb6iSiygNvAw' },
+    ...v3Schema,
+  },
+  // V3-fork deployments on The Graph Network. Both expose the same
+  // `Token.tokenDayData.volumeUSD` shape as native Uniswap V3, so they
+  // slot into v3Schema unchanged.
+  {
+    venue: 'PancakeSwap V3',
+    chain: 'mainnet',
+    endpoint: { kind: 'subgraph', id: 'CJYGNhb7RvnhfBDjqpRnD3oxgyhibzc7fkAMa38YV3oS' },
+    ...v3Schema,
+  },
+  {
+    venue: 'Aerodrome',
+    chain: 'base',
+    endpoint: { kind: 'subgraph', id: 'GENunSHWLBXm59mBSgPzQ8metBEp9YDfdqwFr91Av1UM' },
     ...v3Schema,
   },
 ];

--- a/src/lib/tokens/fetcher.ts
+++ b/src/lib/tokens/fetcher.ts
@@ -12,6 +12,8 @@ import {
 import { classifyAddresses } from './contract-detection';
 import { recordDeficiency } from './deficiencies';
 import { fetchDexVolumes } from './dex-volume';
+import { fetchAllHyperliquidPerps, fetchHyperliquidForSeed, seedToHyperliquidCoin } from './hyperliquid';
+import { fetchAaveV3MultiChain, summariseLending, type LendingChain } from './lending';
 import { TOKEN_SEEDS } from './seed';
 import { fetchPoolStats, type PoolStats } from './pool-stats';
 import { fetchSpotPrices } from './spot-price';
@@ -269,6 +271,9 @@ async function buildSummary(seed: TokenSeed, ethUsd: number | null): Promise<Tok
     top10ContractShare,
     dexVolume24hUsd: null,
     dexVolumeByVenue: {},
+    hyperliquidCoin: null,
+    hyperliquidOiUsd: null,
+    hyperliquidFundingHourly: null,
     altContracts: seed.altContracts ?? {},
     warnings,
     quoteAsOf: Date.now(),
@@ -294,11 +299,15 @@ export async function fetchTokenDirectory(): Promise<TokenSummary[]> {
     chain: s.chain,
     contract: s.contract,
   }));
-  const [summaries, volumes, spotPrices, totalSupplies] = await Promise.all([
+  const [summaries, volumes, spotPrices, totalSupplies, hlPerps] = await Promise.all([
     mapWithConcurrency(TOKEN_SEEDS, 6, (s) => buildSummary(s, ethUsd)),
     fetchDexVolumes(TOKEN_SEEDS),
     fetchSpotPrices(mainnetContracts),
     fetchTotalSupplies(totalSupplyInput),
+    // One paginated sweep of `/v1/hyperliquid/markets` builds a coin →
+    // snapshot map; per-seed lookup is then O(1). Far cheaper than
+    // calling the snapshot endpoint once per seed.
+    fetchAllHyperliquidPerps().catch(() => new Map()),
   ]);
 
   for (const summary of summaries) {
@@ -313,12 +322,29 @@ export async function fetchTokenDirectory(): Promise<TokenSummary[]> {
       summary.totalSupply = ts;
       if (summary.priceUsd != null) summary.fdvUsd = ts * summary.priceUsd;
     }
-    // Override priceUsd with live subgraph spot when available. The
-    // matching seed determines whether to skip pegged stables — they
-    // already short-circuit pricing in buildSummary.
     const seed = TOKEN_SEEDS.find(
       (s) => s.chain === summary.chain && s.contract.toLowerCase() === summary.contract.toLowerCase()
     );
+    // Hyperliquid perps lookup. The mapping function short-circuits for
+    // stablecoins and tokens that don't fit the wrapped/k-prefix patterns,
+    // so this is a cheap O(1) hit on the prebuilt map for ~134 of 153
+    // seeds and a no-op for the rest.
+    if (seed) {
+      const hlCoin = seedToHyperliquidCoin(seed);
+      if (hlCoin) {
+        const market = hlPerps.get(hlCoin);
+        if (market && Number.isFinite(market.price) && market.price > 0) {
+          summary.hyperliquidCoin = hlCoin;
+          const oiTokens = Number(market.open_interest ?? 0);
+          summary.hyperliquidOiUsd = oiTokens > 0 ? oiTokens * market.price : null;
+          summary.hyperliquidFundingHourly =
+            market.funding_rate != null ? Number(market.funding_rate) : null;
+        }
+      }
+    }
+    // Override priceUsd with live subgraph spot when available. The
+    // matching seed determines whether to skip pegged stables — they
+    // already short-circuit pricing in buildSummary.
     if (seed?.pegUsd != null) continue;
     const live = spotPrices.get(summary.contract.toLowerCase());
     if (live != null && live > 0) {
@@ -386,6 +412,8 @@ export async function fetchTokenDetail(
     poolsRaw,
     swapsRaw,
     dexVolumes,
+    aaveReserves,
+    hyperliquid,
   ] = await Promise.all([
     buildSummary(seed, ethUsd),
     fetchPoolOhlc(seed.chain, seed.pool.address, '1d', 100, 1),
@@ -409,6 +437,14 @@ export async function fetchTokenDetail(
     // page's "24h DEX Vol" card stays blank because `buildSummary` only
     // initialises those fields to null.
     fetchDexVolumes([seed]).catch(() => new Map<string, { totalUsd: number; byVenue: Record<string, number> }>()),
+    // Lending market data — Aave V3 across mainnet + Arbitrum + Base +
+    // Polygon + Optimism. Built from the seed's primary contract plus its
+    // `altContracts` map; chains without a known address are skipped.
+    fetchAaveV3MultiChain(buildLendingChainContracts(seed)).catch(() => []),
+    // Hyperliquid perps snapshot. Returns null for any seed without a
+    // matching HL coin (most of the catalog) and silently degrades when
+    // the API is unavailable.
+    fetchHyperliquidForSeed(seed).catch(() => null),
   ]);
   // ETH daily-close benchmark for the volatility comparison. Two pages of
   // 1d × 100 against the same WETH/USDC reference pool the spot lookup uses,
@@ -546,8 +582,23 @@ export async function fetchTokenDetail(
   const recentSwaps = buildSwaps(swapsRaw, seed.contract, summary.priceUsd, ethUsd);
   const performance = buildPerformance(priceSeries);
   const range24h = buildRange24h(priceSeries);
+  const lending = summariseLending(aaveReserves, summary.priceUsd);
 
-  return { summary, priceSeries, benchmarkSeries, topHolders, markets, recentSwaps, performance, range24h };
+  return { summary, priceSeries, benchmarkSeries, topHolders, markets, recentSwaps, performance, range24h, lending, hyperliquid };
+}
+
+// Map a seed's contracts onto the chain keys that the lending module
+// understands. The primary `seed.contract` is the mainnet identifier;
+// `altContracts` covers the four L2s. Chains without a known address
+// fall through (the lending module skips them).
+function buildLendingChainContracts(seed: TokenSeed): Partial<Record<LendingChain, string>> {
+  const out: Partial<Record<LendingChain, string>> = {};
+  if (seed.chain === 'mainnet') out.mainnet = seed.contract;
+  if (seed.altContracts?.arbitrum) out.arbitrum = seed.altContracts.arbitrum;
+  if (seed.altContracts?.base) out.base = seed.altContracts.base;
+  if (seed.altContracts?.polygon) out.polygon = seed.altContracts.polygon;
+  if (seed.altContracts?.optimism) out.optimism = seed.altContracts.optimism;
+  return out;
 }
 
 function buildMarkets(
@@ -643,6 +694,9 @@ function buildSwaps(
     const counterpartySymbol = inIsSeed
       ? s.output_token?.symbol ?? '?'
       : s.input_token?.symbol ?? '?';
+    const counterpartyContract = inIsSeed
+      ? s.output_token?.address ?? null
+      : s.input_token?.address ?? null;
     const amountUsd = priceUsd != null ? tokenAmount * priceUsd : null;
     // Execution price in USD per seed token. Derived from the counterparty
     // leg whenever we know the counterparty's USD value:
@@ -674,6 +728,7 @@ function buildSwaps(
       amount: tokenAmount,
       amountUsd,
       counterpartySymbol,
+      counterpartyContract,
       // Token API exposes three address fields: `user` (originator), `sender`
       // (immediate caller, often a router contract), and `recipient`. `user`
       // is the meaningful "trader" column — the EOA that signed the trade.

--- a/src/lib/tokens/hyperliquid.ts
+++ b/src/lib/tokens/hyperliquid.ts
@@ -1,0 +1,445 @@
+/**
+ * Hyperliquid perps data via the Pinax Token API's Perp Exchange surface
+ * (`/v1/hyperliquid/*`, launched 2026-05-08). Surfaces three signals on the
+ * detail page when a seed has a corresponding HL perp market:
+ *   - Open interest (token + USD)
+ *   - 24h funding (annualized)
+ *   - 24h liquidation activity (count + notional, long/short split)
+ *
+ * The integration is per-detail, not directory-wide: HL exposes ~400 markets
+ * so per-coin lookups are cheap and we don't pay for a fan-out across all
+ * seeds. Two API calls per detail load (snapshot + liquidations OHLC),
+ * issued in parallel with the existing fan-out in `fetcher.ts`.
+ *
+ * Symbol mapping: HL coins are unwrapped tickers (BTC, ETH, SOL, …). We
+ * unwrap the obvious wrapper symbols on our side; everything else passes
+ * through the seed symbol verbatim. LSTs / stablecoins won't have a market,
+ * the API returns an empty array, and the card renders nothing.
+ */
+import { tokenApiGet } from './api';
+import { recordDeficiency } from './deficiencies';
+import type { TokenSeed } from './types';
+
+// --- Endpoint shapes ---
+
+interface HlMarketRow {
+  coin: string;
+  market_name: string;
+  dex: string;
+  price: number;
+  price_24h: number | null;
+  price_24h_change: number;
+  volume_24h: number;
+  buy_volume_24h: number;
+  sell_volume_24h: number;
+  trades_24h: number;
+  unique_users_24h: number;
+  open_interest: number | null;
+  funding_rate: number | null;
+  funding_snapshot_time: string | null;
+}
+
+interface HlPriceOhlcRow {
+  timestamp: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+interface HlLiquidationEventRow {
+  timestamp: string;
+  coin: string;
+  liquidated_user: string;
+  direction: string;
+  notional: number;
+}
+
+interface HlLiquidationOhlcRow {
+  timestamp: string;
+  coin: string;
+  interval_min: number;
+  open: number;
+  close: number;
+  gross_volume: number;
+  close_long_volume: number;
+  close_short_volume: number;
+  transactions: number;
+  unique_liquidated: number;
+}
+
+interface HlOiRow {
+  timestamp: string;
+  coin: string;
+  interval_min: number;
+  open_interest: number;
+  long_positions: number;
+  short_positions: number;
+  long_size: number;
+  short_size: number;
+  funding_rate: number | null;
+}
+
+// --- Public types ---
+
+export interface TokenHyperliquid {
+  /** Hyperliquid coin identifier (e.g. "BTC", "ETH"). */
+  coin: string;
+  /** Direct link to the trade UI for this market. */
+  marketUrl: string;
+  /** Mark price in USD as reported by the exchange. */
+  priceUsd: number;
+  /** 24h price change as a fraction (0.0497 = +4.97%). */
+  priceChange24h: number;
+  /** 24h trade count and unique-trader breadth on this venue. */
+  trades24h: number;
+  uniqueUsers24h: number;
+  /** Most recent UTC-day intraday extremes for the perp's mark price.
+   *  Null when the OHLC fetch failed. */
+  priceHigh24h: number | null;
+  priceLow24h: number | null;
+  /** 24h hourly closes (oldest → newest) for a sparkline. Empty when
+   *  the OHLC fetch failed. */
+  priceHistory24h: number[];
+  /** 24h trading volume in USD. */
+  volume24hUsd: number;
+  /** Open interest in token units. */
+  openInterestTokens: number;
+  /** Open interest in USD (`openInterestTokens * priceUsd`). */
+  openInterestUsd: number;
+  /** OI change vs the same hour 24 hours ago, as a fraction
+   *  (0.082 = +8.2%). Null when the historical bucket isn't available. */
+  openInterestChange24h: number | null;
+  /** 24h hourly OI history in token units (oldest → newest), for a
+   *  sparkline. */
+  openInterestHistory24h: number[];
+  /** 24h trade volume split by side, in USD. From the markets snapshot. */
+  volume24hBuyUsd: number;
+  volume24hSellUsd: number;
+  /** Latest hourly snapshot of trader positioning across this market.
+   *  `long`/`short` are position counts (number of accounts) — a
+   *  sentiment proxy distinct from notional balance. */
+  positioning: {
+    longCount: number;
+    shortCount: number;
+    longSizeTokens: number;
+    shortSizeTokens: number;
+  } | null;
+  /** Hourly funding rate as a decimal (1.25e-5 = +0.00125%/hour). */
+  fundingHourly: number;
+  /** Annualized funding rate as a fraction (`fundingHourly * 24 * 365`). */
+  fundingAnnualized: number;
+  /** 24h hourly funding history (oldest → newest), each value in the
+   *  same hourly-decimal scale as `fundingHourly`. Empty when the OI
+   *  history fetch failed. */
+  fundingHistory24h: number[];
+  /** Whether the funding rate has been pinned at or near HL's baseline
+   *  (≈ 1.25e-5/hr ≈ 10.95% ann.) for ≥6 of the last 24 hours. When
+   *  true, +10.95% is the floor, not a directional signal. */
+  fundingAtBaseline: boolean;
+  /** Last funding snapshot timestamp (server-returned, UTC datetime string). */
+  fundingSnapshotTime: string | null;
+  /** The single largest liquidation event in the latest UTC day, when
+   *  one is reportable. Used as flavor on the card. */
+  largestLiquidation24h: {
+    notionalUsd: number;
+    /** "long" or "short" — the side of the liquidated position. */
+    side: 'long' | 'short';
+    user: string;
+    timestamp: string;
+  } | null;
+  /** Aggregated liquidations over the latest UTC day. */
+  liquidations24h: {
+    /** Number of liquidation events (one transaction per forced exit). */
+    events: number;
+    /** Distinct liquidated wallets in the day. */
+    uniqueUsers: number;
+    /** USD notional of liquidations whose closed positions were long. */
+    longNotionalUsd: number;
+    /** USD notional of liquidations whose closed positions were short. */
+    shortNotionalUsd: number;
+    /** Total USD notional (long + short). */
+    totalNotionalUsd: number;
+    /** Day bucket the figures cover (UTC). */
+    bucketStart: string;
+  } | null;
+}
+
+// Symbol-mapping for cases where HL's coin id differs from the seed's
+// on-chain symbol. Two patterns:
+//
+//   1. Wrapped → underlying. HL lists BTC/ETH (not WBTC/WETH), and we
+//      want the perps card to show on both forms. Other wrappers
+//      (cbBTC, tBTC, cbETH, wstETH, rETH, weETH, etc.) deliberately
+//      don't unwrap because their on-chain economics differ enough
+//      that piping them straight to the underlying perp would mislead.
+//
+//   2. `k`-prefixed memes. HL prices low-unit memecoins as 1000-token
+//      contracts (kPEPE = price per 1k PEPE), so the coin id is
+//      `kSYMBOL` rather than `SYMBOL`. Our seed list carries the bare
+//      symbol; the map translates it.
+const COIN_MAP: Record<string, string> = {
+  WBTC: 'BTC',
+  WETH: 'ETH',
+  PEPE: 'kPEPE',
+  SHIB: 'kSHIB',
+  FLOKI: 'kFLOKI',
+};
+
+export function seedToHyperliquidCoin(seed: TokenSeed): string | null {
+  const sym = (seed.symbol ?? '').toUpperCase();
+  if (!sym) return null;
+  // Stablecoins have no perp; short-circuit so we don't pay an API call.
+  if (seed.tags?.includes('Stablecoin')) return null;
+  return COIN_MAP[sym] ?? sym;
+}
+
+/**
+ * Batched directory fetch — paginates `/v1/hyperliquid/markets` (10 rows
+ * per page on our plan) until exhausted, filters to `dex === 'perps'`,
+ * and returns a `Map<coin, snapshot>` for cheap O(1) per-seed lookup
+ * without making one HTTP request per token. Cost: ~45 parallel calls
+ * once per directory cold load (cached 5 min).
+ */
+export async function fetchAllHyperliquidPerps(): Promise<Map<string, HlMarketRow>> {
+  const out = new Map<string, HlMarketRow>();
+  const PAGE_LIMIT = 50;
+  const tasks: Promise<HlMarketRow[]>[] = [];
+  for (let page = 1; page <= PAGE_LIMIT; page++) {
+    tasks.push(
+      tokenApiGet<HlMarketRow>('/v1/hyperliquid/markets', { page })
+        .then((env) => env.data ?? [])
+        .catch(() => [] as HlMarketRow[])
+    );
+  }
+  const pages = await Promise.all(tasks);
+  for (const rows of pages) {
+    for (const r of rows) {
+      if (r.dex === 'perps') out.set(r.coin, r);
+    }
+  }
+  return out;
+}
+
+async function fetchSnapshot(coin: string): Promise<HlMarketRow | null> {
+  const env = await tokenApiGet<HlMarketRow>('/v1/hyperliquid/markets', { coin });
+  // Filter to perp dex — `markets?coin=` will also match spot pairs that
+  // happen to share the symbol (e.g. base/quote tokens). We only care about
+  // the perpetual market.
+  const perp = (env.data ?? []).find((m) => m.dex === 'perps');
+  return perp ?? null;
+}
+
+async function fetchLiquidationsLastDay(coin: string): Promise<HlLiquidationOhlcRow | null> {
+  // `interval=1d` returns UTC-day buckets, ordered desc; limit=1 is the
+  // current (in-progress) day. The figures roll up all liquidation events
+  // in the bucket, sidestepping the page-size limit on the events endpoint.
+  const env = await tokenApiGet<HlLiquidationOhlcRow>('/v1/hyperliquid/markets/liquidations/ohlc', {
+    coin,
+    interval: '1d',
+    limit: 1,
+  });
+  return env.data?.[0] ?? null;
+}
+
+async function fetchOiHistory24h(coin: string): Promise<HlOiRow[]> {
+  // Hourly buckets over the last 25 hours. Used for two things: the
+  // newest bucket (index 0) carries trader-positioning counts, and the
+  // bucket from 24h ago (index 24) lets us compute the 24h OI delta.
+  // Daily buckets won't work for the delta on the just-rolled UTC day —
+  // the current bucket is incomplete and OI looks artificially small.
+  const env = await tokenApiGet<HlOiRow>('/v1/hyperliquid/markets/oi', {
+    coin,
+    interval: '1h',
+    limit: 25,
+  });
+  return env.data ?? [];
+}
+
+async function fetchPriceOhlc24h(coin: string): Promise<HlPriceOhlcRow[]> {
+  // 24 hourly OHLC bars for the perp's mark price. Drives the price
+  // sparkline + 24h high/low badge.
+  const env = await tokenApiGet<HlPriceOhlcRow>('/v1/hyperliquid/markets/ohlc', {
+    coin,
+    interval: '1h',
+    limit: 24,
+  });
+  return env.data ?? [];
+}
+
+async function fetchLargestLiquidation(coin: string): Promise<HlLiquidationEventRow | null> {
+  // The /markets/liquidations endpoint defaults to ORDER BY notional
+  // DESC, so limit=1 returns the single largest event in the queryable
+  // window. We filter to "today" client-side to avoid surfacing stale
+  // mega-liquidations that aren't relevant.
+  const env = await tokenApiGet<HlLiquidationEventRow>('/v1/hyperliquid/markets/liquidations', {
+    coin,
+    limit: 1,
+  });
+  return env.data?.[0] ?? null;
+}
+
+/**
+ * Fetch the per-seed Hyperliquid summary. Returns `null` when no perp
+ * market exists for the seed's mapped coin (most of our catalog).
+ *
+ * Liquidation aggregates are best-effort: a missing OHLC row just leaves
+ * `liquidations24h` as `null` rather than failing the whole card.
+ */
+export async function fetchHyperliquidForSeed(seed: TokenSeed): Promise<TokenHyperliquid | null> {
+  const coin = seedToHyperliquidCoin(seed);
+  if (!coin) return null;
+  // Five HL endpoints, all in parallel. Most return empty data (not
+  // errors) for coins without a perp market, so issuing them
+  // speculatively for non-listed seeds is safe. Latency is bounded by
+  // the slowest call rather than the sum.
+  const [snapshot, liqRow, oiRows, ohlcRows, biggestLiq] = await Promise.all([
+    fetchSnapshot(coin).catch((e) => {
+      recordDeficiency(
+        'HYPERLIQUID_SNAPSHOT_FAILED',
+        `hyperliquid markets ${coin}: ${(e as Error).message}`
+      );
+      return null;
+    }),
+    fetchLiquidationsLastDay(coin).catch((e) => {
+      recordDeficiency(
+        'HYPERLIQUID_LIQUIDATIONS_FAILED',
+        `hyperliquid liquidations/ohlc ${coin}: ${(e as Error).message}`
+      );
+      return null;
+    }),
+    fetchOiHistory24h(coin).catch((e) => {
+      recordDeficiency(
+        'HYPERLIQUID_OI_FAILED',
+        `hyperliquid markets/oi ${coin}: ${(e as Error).message}`
+      );
+      return [] as HlOiRow[];
+    }),
+    fetchPriceOhlc24h(coin).catch((e) => {
+      recordDeficiency(
+        'HYPERLIQUID_OHLC_FAILED',
+        `hyperliquid markets/ohlc ${coin}: ${(e as Error).message}`
+      );
+      return [] as HlPriceOhlcRow[];
+    }),
+    fetchLargestLiquidation(coin).catch((e) => {
+      recordDeficiency(
+        'HYPERLIQUID_BIG_LIQ_FAILED',
+        `hyperliquid markets/liquidations ${coin}: ${(e as Error).message}`
+      );
+      return null;
+    }),
+  ]);
+  if (!snapshot) return null;
+
+  const priceUsd = Number(snapshot.price ?? 0);
+  const oiTokens = Number(snapshot.open_interest ?? 0);
+  const fundingHourly = Number(snapshot.funding_rate ?? 0);
+  // OI 24h delta from the hourly history. Compares the newest bucket
+  // (index 0) to the bucket ~24 hours ago (last in the desc-ordered
+  // limit=25 page). When the page returns fewer than expected (fresh
+  // listing, indexer gap), fall back to null so the UI omits the line.
+  const oiNow = oiRows[0]?.open_interest;
+  const oiThen = oiRows[oiRows.length - 1]?.open_interest;
+  const openInterestChange24h =
+    oiRows.length >= 2 && Number.isFinite(oiNow) && Number.isFinite(oiThen) && oiThen > 0
+      ? (oiNow - oiThen) / oiThen
+      : null;
+  // Trader positioning: counts from the newest hourly bucket. `short_size`
+  // is signed negative in the schema; we surface absolute token magnitudes.
+  const positioning = oiRows[0]
+    ? {
+        longCount: Number(oiRows[0].long_positions ?? 0),
+        shortCount: Number(oiRows[0].short_positions ?? 0),
+        longSizeTokens: Math.abs(Number(oiRows[0].long_size ?? 0)),
+        shortSizeTokens: Math.abs(Number(oiRows[0].short_size ?? 0)),
+      }
+    : null;
+  // Funding history (oldest → newest), each value in hourly-decimal scale.
+  // Used both for the sparkline and for the "at baseline" regime check —
+  // HL's per-asset baseline rate sits ≈ 1.25e-5/hr (≈ 10.95% ann.).
+  const fundingHistory24h = [...oiRows]
+    .reverse()
+    .map((r) => Number(r.funding_rate ?? 0))
+    .filter((n) => Number.isFinite(n));
+  const HL_BASELINE = 1.25e-5;
+  const baselineHits = fundingHistory24h.filter(
+    (f) => Math.abs(f - HL_BASELINE) < HL_BASELINE * 0.05 || Math.abs(f + HL_BASELINE) < HL_BASELINE * 0.05
+  ).length;
+  const fundingAtBaseline = fundingHistory24h.length >= 6 && baselineHits >= 6;
+  // OI sparkline (oldest → newest), in token units.
+  const openInterestHistory24h = [...oiRows]
+    .reverse()
+    .map((r) => Number(r.open_interest ?? 0))
+    .filter((n) => Number.isFinite(n));
+  // Price extremes + sparkline. OHLC rows are returned newest-first.
+  const ohlcAsc = [...ohlcRows].reverse();
+  const priceHigh24h = ohlcRows.length > 0 ? Math.max(...ohlcRows.map((r) => Number(r.high))) : null;
+  const priceLow24h = ohlcRows.length > 0 ? Math.min(...ohlcRows.map((r) => Number(r.low))) : null;
+  const priceHistory24h = ohlcAsc.map((r) => Number(r.close)).filter((n) => Number.isFinite(n) && n > 0);
+  // Biggest single liquidation event today — only surface when it's
+  // recent (≤24h) and has meaningful notional, otherwise we'd be
+  // showing yesterday's drama as today's flavor.
+  const NOW_MS = Date.now();
+  let largestLiquidation24h: TokenHyperliquid['largestLiquidation24h'] = null;
+  if (biggestLiq && Number(biggestLiq.notional) > 0) {
+    const eventMs = new Date(biggestLiq.timestamp.replace(' ', 'T') + 'Z').getTime();
+    const ageHours = (NOW_MS - eventMs) / (1000 * 60 * 60);
+    if (Number.isFinite(ageHours) && ageHours <= 24) {
+      const sideRaw = biggestLiq.direction.toUpperCase();
+      const side: 'long' | 'short' = sideRaw.includes('LONG') ? 'long' : 'short';
+      largestLiquidation24h = {
+        notionalUsd: Number(biggestLiq.notional),
+        side,
+        user: biggestLiq.liquidated_user,
+        timestamp: biggestLiq.timestamp,
+      };
+    }
+  }
+  const liquidations24h = liqRow
+    ? (() => {
+        // Liquidation OHLC volumes are already USD-denominated (cross-
+        // checked against `/v1/hyperliquid/platform.liquidations_volume`,
+        // which sums these by day across all coins and resolves to plausible
+        // platform totals e.g. ~$33M/day). The `open`/`close` fields on the
+        // candle are mark prices and are NOT a USD-conversion factor.
+        const longUsd = Number(liqRow.close_long_volume ?? 0);
+        const shortUsd = Number(liqRow.close_short_volume ?? 0);
+        return {
+          events: Number(liqRow.transactions ?? 0),
+          uniqueUsers: Number(liqRow.unique_liquidated ?? 0),
+          longNotionalUsd: longUsd,
+          shortNotionalUsd: shortUsd,
+          totalNotionalUsd: longUsd + shortUsd,
+          bucketStart: liqRow.timestamp,
+        };
+      })()
+    : null;
+
+  return {
+    coin,
+    marketUrl: `https://app.hyperliquid.xyz/trade/${encodeURIComponent(coin)}`,
+    priceUsd,
+    priceChange24h: Number(snapshot.price_24h_change ?? 0),
+    trades24h: Number(snapshot.trades_24h ?? 0),
+    uniqueUsers24h: Number(snapshot.unique_users_24h ?? 0),
+    priceHigh24h,
+    priceLow24h,
+    priceHistory24h,
+    volume24hUsd: Number(snapshot.volume_24h ?? 0),
+    volume24hBuyUsd: Number(snapshot.buy_volume_24h ?? 0),
+    volume24hSellUsd: Number(snapshot.sell_volume_24h ?? 0),
+    openInterestTokens: oiTokens,
+    openInterestUsd: oiTokens * priceUsd,
+    openInterestChange24h,
+    openInterestHistory24h,
+    fundingHourly,
+    fundingAnnualized: fundingHourly * 24 * 365,
+    fundingHistory24h,
+    fundingAtBaseline,
+    fundingSnapshotTime: snapshot.funding_snapshot_time,
+    positioning,
+    liquidations24h,
+    largestLiquidation24h,
+  };
+}

--- a/src/lib/tokens/lending.ts
+++ b/src/lib/tokens/lending.ts
@@ -1,0 +1,347 @@
+/**
+ * Lending-market data for tokens used as collateral or borrow assets.
+ * Sources Aave V3 across all five Graph-Network deployments (Ethereum,
+ * Arbitrum, Base, Polygon, Optimism) in parallel. Future iterations can
+ * layer in Compound, Morpho, Spark, etc. with the same shape.
+ *
+ * Why this exists: Token API has no notion of "listed in lending markets",
+ * so the directory and detail page have no signal for whether a token
+ * functions as collateral. Aave V3 alone gives us total supplied, total
+ * borrowed, utilization and rates per asset for the bulk of the blue-chip
+ * universe across the chains we already track.
+ *
+ * Schema notes (Aave V3 subgraph):
+ *  - `liquidityRate` and `variableBorrowRate` are ray (1e27) APR values.
+ *    Aave UIs typically display the APR; APY would compound per-second.
+ *  - `totalATokenSupply` and `totalCurrentVariableDebt` are in token base
+ *    units; divide by `10^decimals` to get human units.
+ *  - `price.priceInEth` is misleadingly named — V3 uses USD-denominated
+ *    Chainlink feeds with 8 decimals. The field kept its V1/V2 name. Some
+ *    reserves return `0` (indexer gap, e.g. WBTC at the time of writing),
+ *    so we accept a fallback price from the caller.
+ */
+import { recordDeficiency } from './deficiencies';
+
+const GW_BASE = 'https://gateway-arbitrum.network.thegraph.com/api';
+const RAY = 1e27;
+const AAVE_PRICE_DECIMALS = 1e8;
+
+export type LendingChain = 'mainnet' | 'arbitrum' | 'base' | 'polygon' | 'optimism';
+
+interface AaveDeployment {
+  chain: LendingChain;
+  /** IPFS deployment hash (Qm…). Source: Graph Network gateway. */
+  hash: string;
+}
+
+// Aave V3 deployments on The Graph Network. Discovered via the
+// graph-aave MCP and verified individually against the gateway. The
+// gateway accepts deployment hashes through `/deployments/id/<hash>`.
+// Exported so smoke tests / coverage scripts can iterate over the same
+// list this module queries against.
+export const AAVE_V3_DEPLOYMENTS: AaveDeployment[] = [
+  { chain: 'mainnet', hash: 'QmX2VfvEspbShTdcjefWeG3CKBVXKWm9naxH6TVhqPb9qY' },
+  { chain: 'arbitrum', hash: 'Qmdn5hAZZj3wmWVuksXHtua3E6aWftCDeTFcW8YQ8Lu6pB' },
+  { chain: 'base', hash: 'QmXZ53Kzz3L2LvvbGve2ebtLKWMhjjB1a3U2jnUj2YwGCW' },
+  { chain: 'polygon', hash: 'QmceoHP3ekxJ6JYqAXhqrVgv8rb9WXumrGe1ZhVZah8Ar5' },
+  { chain: 'optimism', hash: 'QmScPH3aFxzFgrie8MMDU4QtFu3CE7nTfsRfSQXiccxBPh' },
+];
+
+export interface LendingMarket {
+  protocol: 'Aave V3 Core';
+  chain: LendingChain;
+  /** Lowercased underlying asset address as listed on `chain` — needed for
+   *  the per-chain Aave deep link, since L2 token addresses differ from L1. */
+  underlyingAsset: string;
+  /** Direct link to the Aave reserve-overview page for this asset/chain. */
+  aaveMarketUrl: string;
+  isActive: boolean;
+  isFrozen: boolean;
+  borrowingEnabled: boolean;
+  collateralEnabled: boolean;
+  /** Decimal-adjusted supply in token units. */
+  totalSuppliedTokens: number;
+  /** USD value of supply. Null when neither subgraph price nor caller fallback resolved. */
+  totalSuppliedUsd: number | null;
+  /** Decimal-adjusted variable-rate debt in token units. */
+  totalBorrowedTokens: number;
+  /** USD value of variable-rate debt. */
+  totalBorrowedUsd: number | null;
+  /** Liquidity available to borrow right now, in token units. Equals
+   *  `totalSuppliedTokens - totalBorrowedTokens` modulo any aToken reserves
+   *  the protocol holds back; we use the subgraph's `availableLiquidity`
+   *  field which is the authoritative figure. */
+  availableLiquidityTokens: number;
+  /** USD value of `availableLiquidityTokens`. */
+  availableLiquidityUsd: number | null;
+  /** Borrowed / supplied in token units, 0..1. */
+  utilization: number;
+  /** Supply APR as a decimal (0.0329 = 3.29%). */
+  supplyApr: number;
+  /** Variable-rate borrow APR as a decimal. */
+  variableBorrowApr: number;
+  /** Liquidation threshold in basis points (e.g. 7800 = 78%). Null when not collateralised. */
+  liquidationThresholdBps: number | null;
+  /** Per-asset supply cap in whole tokens. `null` when uncapped. Aave V3
+   *  stores caps as plain integers (no decimal scaling); a cap of 0 means
+   *  "no cap" so we fold that to null. */
+  supplyCapTokens: number | null;
+  /** Per-asset borrow cap in whole tokens. `null` when uncapped. */
+  borrowCapTokens: number | null;
+  /** USD price actually used to derive `totalSuppliedUsd` /
+   *  `totalBorrowedUsd` for this row. Set initially to the per-subgraph
+   *  Aave oracle price (or null when the oracle reports 0, e.g. WBTC),
+   *  then overwritten by `summariseLending` with the seed's canonical
+   *  spot price when one is available — that override is what keeps
+   *  cross-chain aggregation on a single price basis. Read this as the
+   *  valuation price, not necessarily the protocol's own oracle. */
+  priceUsd: number | null;
+}
+
+export interface TokenLending {
+  /** Per-deployment markets, sorted by `totalSuppliedUsd` desc. */
+  markets: LendingMarket[];
+  /** Aggregate `totalSuppliedUsd` across markets. Null when no USD figures resolved. */
+  totalSuppliedUsd: number | null;
+  totalBorrowedUsd: number | null;
+  /** Aggregate borrowable liquidity in USD across markets. Null when no
+   *  USD figures resolved. */
+  availableLiquidityUsd: number | null;
+  /** Aggregate utilization, 0..1. Null when no supply. */
+  utilization: number | null;
+}
+
+interface ReserveRow {
+  underlyingAsset: string;
+  symbol: string;
+  decimals: number;
+  isActive: boolean;
+  isFrozen: boolean;
+  borrowingEnabled: boolean;
+  usageAsCollateralEnabled: boolean;
+  totalATokenSupply: string;
+  totalCurrentVariableDebt: string;
+  /** Borrowable liquidity in base units (same scale as totalATokenSupply). */
+  availableLiquidity: string | null;
+  /** Per-asset cap in WHOLE tokens (no decimal scaling); 0 means uncapped. */
+  supplyCap: string | null;
+  /** Per-asset cap in WHOLE tokens (no decimal scaling); 0 means uncapped. */
+  borrowCap: string | null;
+  liquidityRate: string;
+  variableBorrowRate: string;
+  reserveLiquidationThreshold: string | null;
+  price: { priceInEth: string } | null;
+}
+
+interface ReservesResponse {
+  data?: { reserves: ReserveRow[] };
+  errors?: Array<{ message: string }>;
+}
+
+function rayToApr(ray: string | null | undefined): number {
+  const n = Number(ray ?? '0');
+  if (!Number.isFinite(n)) return 0;
+  return n / RAY;
+}
+
+function tokenUnits(raw: string | null | undefined, decimals: number): number {
+  if (!raw) return 0;
+  try {
+    const big = BigInt(raw.split('.')[0] ?? '0');
+    return Number(big) / 10 ** decimals;
+  } catch {
+    return Number(raw) / 10 ** decimals;
+  }
+}
+
+const RESERVES_QUERY = `
+  query AaveV3Reserves($ids: [Bytes!]!) {
+    reserves(where: { underlyingAsset_in: $ids }, first: 200) {
+      underlyingAsset
+      symbol
+      decimals
+      isActive
+      isFrozen
+      borrowingEnabled
+      usageAsCollateralEnabled
+      totalATokenSupply
+      totalCurrentVariableDebt
+      availableLiquidity
+      supplyCap
+      borrowCap
+      liquidityRate
+      variableBorrowRate
+      reserveLiquidationThreshold
+      price { priceInEth }
+    }
+  }
+`;
+
+// Aave's reserve-overview routes are scoped by a `marketName` slug; the
+// chain key in `LendingChain` lines up cleanly with their convention.
+const AAVE_MARKET_NAME: Record<LendingChain, string> = {
+  mainnet: 'proto_mainnet_v3',
+  arbitrum: 'proto_arbitrum_v3',
+  base: 'proto_base_v3',
+  polygon: 'proto_polygon_v3',
+  optimism: 'proto_optimism_v3',
+};
+
+function aaveReserveUrl(chain: LendingChain, underlyingAsset: string): string {
+  const market = AAVE_MARKET_NAME[chain];
+  const addr = underlyingAsset.toLowerCase();
+  return `https://app.aave.com/reserve-overview/?underlyingAsset=${addr}&marketName=${market}`;
+}
+
+async function queryDeployment(
+  apiKey: string,
+  deployment: AaveDeployment,
+  contractsLower: string[]
+): Promise<LendingMarket[]> {
+  if (contractsLower.length === 0) return [];
+  const url = `${GW_BASE}/${apiKey}/deployments/id/${deployment.hash}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: RESERVES_QUERY, variables: { ids: contractsLower } }),
+  });
+  if (!res.ok) throw new Error(`aave v3 ${deployment.chain} ${res.status}`);
+  const body = (await res.json()) as ReservesResponse;
+  if (body.errors?.length) throw new Error(body.errors.map((e) => e.message).join('; '));
+  const out: LendingMarket[] = [];
+  for (const r of body.data?.reserves ?? []) {
+    const decimals = Number(r.decimals) || 18;
+    const supplied = tokenUnits(r.totalATokenSupply, decimals);
+    const borrowed = tokenUnits(r.totalCurrentVariableDebt, decimals);
+    const available = tokenUnits(r.availableLiquidity, decimals);
+    const priceUsd = Number(r.price?.priceInEth ?? '0') / AAVE_PRICE_DECIMALS;
+    const validPrice = Number.isFinite(priceUsd) && priceUsd > 0 ? priceUsd : null;
+    const liqBps = r.reserveLiquidationThreshold ? Number(r.reserveLiquidationThreshold) : null;
+    // Caps are plain integers in whole tokens; 0 means uncapped on Aave V3.
+    const supplyCapRaw = Number(r.supplyCap ?? '0');
+    const borrowCapRaw = Number(r.borrowCap ?? '0');
+    out.push({
+      protocol: 'Aave V3 Core',
+      chain: deployment.chain,
+      underlyingAsset: r.underlyingAsset.toLowerCase(),
+      aaveMarketUrl: aaveReserveUrl(deployment.chain, r.underlyingAsset),
+      isActive: !!r.isActive,
+      isFrozen: !!r.isFrozen,
+      borrowingEnabled: !!r.borrowingEnabled,
+      collateralEnabled: !!r.usageAsCollateralEnabled,
+      totalSuppliedTokens: supplied,
+      totalSuppliedUsd: validPrice != null ? supplied * validPrice : null,
+      totalBorrowedTokens: borrowed,
+      totalBorrowedUsd: validPrice != null ? borrowed * validPrice : null,
+      availableLiquidityTokens: available,
+      availableLiquidityUsd: validPrice != null ? available * validPrice : null,
+      utilization: supplied > 0 ? Math.min(1, borrowed / supplied) : 0,
+      supplyApr: rayToApr(r.liquidityRate),
+      variableBorrowApr: rayToApr(r.variableBorrowRate),
+      liquidationThresholdBps: liqBps && liqBps > 0 ? liqBps : null,
+      supplyCapTokens: Number.isFinite(supplyCapRaw) && supplyCapRaw > 0 ? supplyCapRaw : null,
+      borrowCapTokens: Number.isFinite(borrowCapRaw) && borrowCapRaw > 0 ? borrowCapRaw : null,
+      priceUsd: validPrice,
+    });
+  }
+  return out;
+}
+
+/**
+ * Fetch every Aave V3 listing for a single seed across all five
+ * deployments. The caller passes a chain → contract map so we can use
+ * the seed's `altContracts` for L2 lookups (the L1 contract address
+ * does not match the L2 deployment).
+ */
+export async function fetchAaveV3MultiChain(
+  chainContracts: Partial<Record<LendingChain, string>>
+): Promise<LendingMarket[]> {
+  const apiKey = process.env.GRAPH_API_KEY;
+  if (!apiKey) return [];
+  const tasks = AAVE_V3_DEPLOYMENTS.map(async (d) => {
+    const contract = chainContracts[d.chain];
+    if (!contract) return [] as LendingMarket[];
+    try {
+      return await queryDeployment(apiKey, d, [contract.toLowerCase()]);
+    } catch (e) {
+      recordDeficiency(
+        'AAVE_V3_QUERY_FAILED',
+        `aave v3 ${d.chain}: ${(e as Error).message}`
+      );
+      return [] as LendingMarket[];
+    }
+  });
+  const results = await Promise.all(tasks);
+  return results.flat();
+}
+
+/**
+ * Build a `TokenLending` summary from a list of markets. `canonicalPriceUsd`
+ * is the seed's authoritative live USD price (typically from the Uniswap V3
+ * mainnet spot module). When provided it overrides the per-subgraph oracle
+ * price for *every* market, then drives `totalSuppliedUsd` /
+ * `totalBorrowedUsd`. This is the right behavior for cross-chain
+ * aggregation: each L2's Aave oracle has its own update cadence and can
+ * drift materially (observed: WBTC mainnet $79.9k vs Polygon $56.6k vs
+ * Arbitrum $66.6k on the same wall-clock day), and aggregating across
+ * different price bases produces nonsense USDs. Per-subgraph oracle prices
+ * are still surfaced via `priceUsd` for callers that want them.
+ *
+ * Falls back to the per-subgraph oracle price only when no canonical price
+ * was supplied, so the card still renders something for tokens we have no
+ * spot reference for.
+ */
+export function summariseLending(
+  markets: LendingMarket[],
+  canonicalPriceUsd: number | null
+): TokenLending | null {
+  if (markets.length === 0) return null;
+  const haveCanonical = canonicalPriceUsd != null && canonicalPriceUsd > 0;
+  const adjusted = markets.map((m) => {
+    if (haveCanonical) {
+      const p = canonicalPriceUsd as number;
+      return {
+        ...m,
+        totalSuppliedUsd: m.totalSuppliedTokens * p,
+        totalBorrowedUsd: m.totalBorrowedTokens * p,
+        availableLiquidityUsd: m.availableLiquidityTokens * p,
+        priceUsd: p,
+      };
+    }
+    return m;
+  });
+  let totalSuppliedUsd = 0;
+  let totalBorrowedUsd = 0;
+  let totalAvailableUsd = 0;
+  let hasSuppliedUsd = false;
+  let hasBorrowedUsd = false;
+  let hasAvailableUsd = false;
+  for (const m of adjusted) {
+    if (m.totalSuppliedUsd != null) {
+      totalSuppliedUsd += m.totalSuppliedUsd;
+      hasSuppliedUsd = true;
+    }
+    if (m.totalBorrowedUsd != null) {
+      totalBorrowedUsd += m.totalBorrowedUsd;
+      hasBorrowedUsd = true;
+    }
+    if (m.availableLiquidityUsd != null) {
+      totalAvailableUsd += m.availableLiquidityUsd;
+      hasAvailableUsd = true;
+    }
+  }
+  // Markets sort largest-deployment-first so the UI leads with what
+  // matters. Falls back to chain ordering when neither has USD.
+  adjusted.sort((a, b) => (b.totalSuppliedUsd ?? 0) - (a.totalSuppliedUsd ?? 0));
+  const aggregateUtil =
+    hasSuppliedUsd && totalSuppliedUsd > 0 && hasBorrowedUsd
+      ? Math.min(1, totalBorrowedUsd / totalSuppliedUsd)
+      : null;
+  return {
+    markets: adjusted,
+    totalSuppliedUsd: hasSuppliedUsd ? totalSuppliedUsd : null,
+    totalBorrowedUsd: hasBorrowedUsd ? totalBorrowedUsd : null,
+    availableLiquidityUsd: hasAvailableUsd ? totalAvailableUsd : null,
+    utilization: aggregateUtil,
+  };
+}

--- a/src/lib/tokens/seed.ts
+++ b/src/lib/tokens/seed.ts
@@ -27,6 +27,7 @@ export const TOKEN_SEEDS: TokenSeed[] = [
       arbitrum: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
       base: '0x4200000000000000000000000000000000000006',
       polygon: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
+      optimism: '0x4200000000000000000000000000000000000006',
     },
   },
   {
@@ -45,6 +46,7 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     altContracts: {
       arbitrum: '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
       polygon: '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6',
+      optimism: '0x68f180fcce6836688e9084f035309e29bf0a2095',
     },
   },
   {
@@ -68,6 +70,7 @@ export const TOKEN_SEEDS: TokenSeed[] = [
       arbitrum: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
       base: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
       polygon: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+      optimism: '0x7f5c764cbc14f9669b88837ca1490cca17c31607',
     },
   },
   {
@@ -107,6 +110,7 @@ export const TOKEN_SEEDS: TokenSeed[] = [
       arbitrum: '0xf97f4df75117a78c1a5a0dbb814af92458539fb4',
       base: '0x88fb150bdc53a65fe94dea0c9ba0a6daf8c6e196',
       polygon: '0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39',
+      optimism: '0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6',
     },
   },
   {
@@ -144,6 +148,7 @@ export const TOKEN_SEEDS: TokenSeed[] = [
       arbitrum: '0xba5ddd1f9d7f570dc94a51479a000e3bce967196',
       base: '0xa88594d404727625a9437c3f886c7643872296ae',
       polygon: '0xd6df932a45c0f255f85145f286ea0b292b21c90b',
+      optimism: '0x76fb31fb4af56892a25e32cfc43de717950c9278',
     },
   },
   {
@@ -255,7 +260,11 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'usdt',
     website: 'https://tether.to',
     tags: ['Stablecoin'],
-    altContracts: {arbitrum:"0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",polygon:"0xc2132d05d31c914a87c6611c10748aeb04b58e8f"},
+    altContracts: {
+      arbitrum: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+      polygon: '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
+      optimism: '0x94b008aa00579c1307b0ef2c499ad98a8ce58e58',
+    },
   },
   {
     contract: '0x6b175474e89094c44da98b954eedeac495271d0f',
@@ -272,7 +281,11 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'dai',
     website: 'https://makerdao.com',
     tags: ['Stablecoin'],
-    altContracts: {arbitrum:"0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",polygon:"0x8f3cf7ad23cd3cadbd9735aff958023239c6a063"},
+    altContracts: {
+      arbitrum: '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1',
+      polygon: '0x8f3cf7ad23cd3cadbd9735aff958023239c6a063',
+      optimism: '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1',
+    },
   },
   {
     contract: '0x853d955acef822db058eb8505911ed77f175b99e',
@@ -287,6 +300,9 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'frax',
     website: 'https://frax.finance',
     tags: ['Stablecoin'],
+    altContracts: {
+      arbitrum: '0x17fc002b466eec40dae837fc4be5c67993ddbd6f',
+    },
   },
   {
     contract: '0xc5f0f7b66764f6ec8c8dff7ba683102295e16409',
@@ -329,6 +345,10 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'lusd',
     website: 'https://www.liquity.org',
     tags: ['Stablecoin'],
+    altContracts: {
+      arbitrum: '0x93b346b6bc2548da6a1e7d98e9a421b42541425b',
+      optimism: '0xc40f949f8a4e094d1b49a23ea9241d289b7b2819',
+    },
   },
   {
     // Was previously a wrong contract (Biconomy's BICO) under the GHO
@@ -345,6 +365,10 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'gho',
     website: 'https://gho.aave.com',
     tags: ['Stablecoin'],
+    altContracts: {
+      arbitrum: '0x7dff72693f6a4149b17e7c6314655f6a9f7c8b33',
+      base: '0x6bb7a212910682dcfdbd5bcbb3e28fb4e8da10ee',
+    },
   },
   {
     contract: '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e',
@@ -387,7 +411,12 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'wsteth',
     website: 'https://lido.fi',
     tags: ['LST'],
-    altContracts: {arbitrum:"0x5979d7b546e38e414f7e9822514be443a4800529",base:"0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",polygon:"0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd"},
+    altContracts: {
+      arbitrum: '0x5979d7b546e38e414f7e9822514be443a4800529',
+      base: '0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452',
+      polygon: '0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd',
+      optimism: '0x1f32b1c2345538c0c6f582fcb022739c4a194ebb',
+    },
   },
   {
     contract: '0xae78736cd615f374d3085123a210448e74fc6393',
@@ -402,7 +431,11 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'reth',
     website: 'https://www.rocketpool.net',
     tags: ['LST'],
-    altContracts: {arbitrum:"0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",base:"0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c"},
+    altContracts: {
+      arbitrum: '0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8',
+      base: '0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c',
+      optimism: '0x9bcef72be871e61ed4fbbc7630889bee758eb81d',
+    },
   },
   {
     contract: '0xbe9895146f7af43049ca1c1ae358b0541ea49704',
@@ -417,7 +450,9 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'cbeth',
     website: 'https://www.coinbase.com/cbeth',
     tags: ['LST'],
-    altContracts: {base:"0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22"},
+    altContracts: {
+      base: '0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22',
+    },
   },
   {
     contract: '0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee',
@@ -432,7 +467,10 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'weeth',
     website: 'https://www.ether.fi',
     tags: ['LST'],
-    altContracts: {arbitrum:"0x35751007a407ca6feffe80b3cb397736d2cf4dbe",base:"0x04c0599ae5a44757c0af6f9ec3b93da8976c150a"},
+    altContracts: {
+      arbitrum: '0x35751007a407ca6feffe80b3cb397736d2cf4dbe',
+      base: '0x04c0599ae5a44757c0af6f9ec3b93da8976c150a',
+    },
   },
   {
     contract: '0xbf5495efe5db9ce00f80364c8b423567e58d2110',
@@ -447,6 +485,10 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'ezeth',
     website: 'https://www.renzoprotocol.com',
     tags: ['LST'],
+    altContracts: {
+      arbitrum: '0x2416092f143378750bb29b79ed961ab195cceea5',
+      base: '0x2416092f143378750bb29b79ed961ab195cceea5',
+    },
   },
   {
     contract: '0xac3e018457b222d93114458476f3e3416abbe38f',
@@ -503,6 +545,9 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'bal',
     website: 'https://balancer.fi',
     tags: ['DEX', 'Governance'],
+    altContracts: {
+      polygon: '0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3',
+    },
   },
   {
     contract: '0x808507121b80c02388fad14726482e061b8da827',
@@ -601,7 +646,9 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'arb',
     website: 'https://arbitrum.foundation',
     tags: ['Infrastructure', 'Governance'],
-    altContracts: {arbitrum:"0x912ce59144191c1204e64559fe8253a0e49e6548"},
+    altContracts: {
+      arbitrum: '0x912ce59144191c1204e64559fe8253a0e49e6548',
+    },
   },
   {
     contract: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
@@ -912,6 +959,9 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'rseth',
     website: 'https://kelpdao.xyz',
     tags: ['LST', 'Restaking'],
+    altContracts: {
+      arbitrum: '0x4186bfc76e2e237523cbc30fd220fe055156b41f',
+    },
   },
   // SWELL/WETH 10000bps  TVL=$51,081
   {
@@ -1974,6 +2024,9 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'cbbtc',
     website: 'https://www.coinbase.com/cbbtc',
     tags: ['Wrapped'],
+    altContracts: {
+      base: '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf',
+    },
   },
   // tBTC/WETH 30bps  TVL=$542,637
   {
@@ -1988,6 +2041,10 @@ export const TOKEN_SEEDS: TokenSeed[] = [
     iconSlug: 'tbtc',
     website: 'https://threshold.network',
     tags: ['Wrapped'],
+    altContracts: {
+      arbitrum: '0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40',
+      base: '0x236aa50979d5f3de3bd1eeb40e81137f22ab794b',
+    },
   },
   // MORPHO/WETH 100bps  TVL=$1,974,734
   {

--- a/src/lib/tokens/types.ts
+++ b/src/lib/tokens/types.ts
@@ -110,6 +110,16 @@ export interface TokenSummary {
    */
   dexVolume24hUsd: number | null;
   dexVolumeByVenue: Record<string, number>;
+  /** Hyperliquid perp coin id (e.g. "BTC", "kPEPE"). Non-null when the
+   *  seed maps to a live HL perp market — drives the "Perps" badge and
+   *  the HL OI column on the directory. */
+  hyperliquidCoin: string | null;
+  /** HL open interest in USD (token notional × mark). Null when no
+   *  perp market or OI is unreported. */
+  hyperliquidOiUsd: number | null;
+  /** HL hourly funding rate as a decimal. Sign + magnitude drive the
+   *  inline direction indicator on the directory's HL OI column. */
+  hyperliquidFundingHourly: number | null;
   /**
    * Cross-chain deployments hand-curated in the seed. Same project, different
    * chain, different contract. Empty when the token only exists on its
@@ -171,6 +181,9 @@ export interface TokenSwap {
   /** USD value, when computable from priceUsd. */
   amountUsd: number | null;
   counterpartySymbol: string;
+  /** Counterparty token contract — drives the inline icon in the swap row's
+   *  Pair column (otherwise we'd only have a symbol fallback). */
+  counterpartyContract: string | null;
   /** Originator of the swap — typically the EOA (or proxy) that signed.
    *  Used for the swap row's "Trader" column linked to Etherscan. */
   trader: string;
@@ -209,4 +222,13 @@ export interface TokenDetail {
   recentSwaps: TokenSwap[];
   performance: TokenPerformance;
   range24h: TokenRange24h | null;
+  /** Aggregated lending-market data when the token is listed in any
+   *  supported protocol (currently Aave V3 Core across Ethereum +
+   *  Arbitrum + Base + Polygon + Optimism, rolled up to a single
+   *  cross-chain summary). Null when the token isn't a lending-market
+   *  asset. */
+  lending: import('./lending').TokenLending | null;
+  /** Hyperliquid perps-market summary when a corresponding perp exists.
+   *  Null when no HL market matches the seed (most of the catalog). */
+  hyperliquid: import('./hyperliquid').TokenHyperliquid | null;
 }


### PR DESCRIPTION
## Summary
- Multi-chain Aave V3 lending data (Ethereum/Arbitrum/Base/Polygon/Optimism) rolled up into one LendingCard with canonical-price override and per-chain breakdowns
- Hyperliquid perps integration on detail (5 endpoints in parallel: regime, OI, liquidations, funding, mark) and bulk perp-coverage on the directory
- Detail-page UX overhaul: sticky token bar, section nav, single-column flow, symbol-prefixed card headers, "Markets" → "Spot Pools", consistent icon hierarchy, pair logos on both legs in Spot Pools / Recent Swaps, chain logos in Lending, brand logos on every off-site CTA
- Tables (Spot Pools, Recent Swaps) switched to `table-fixed` so columns spread evenly across the card width; Trade column left-aligned so protocol logos line up vertically; Tx column shows a fuller short hash
- Tokens directory: dropped 90d% and EOA share, added HL Open Interest column with funding direction marker, "Perps" badge on Token cell
- TokenIcon fallback chain extended (DefiLlama + 1inch token CDNs) so swap counterparties outside the 154-token seed set resolve to brand logos instead of gradient initials

## Test plan
- [ ] `/tokens` directory: HL OI column populated for tokens with HL perps; "Perps" badge renders; existing sort/filter still works
- [ ] `/tokens/mainnet/<aave-listed-asset>`: LendingCard shows per-chain rows for the 5 chains the asset is listed on, "Open in Aave" deep-links work, best-supply/cheapest-borrow highlight cards render
- [ ] `/tokens/mainnet/<HL-listed-asset>` (e.g. WBTC, ETH, PEPE): HyperliquidCard renders with regime, OI, funding, liquidations, sparklines
- [ ] Spot Pools card: pair logos load on both legs, columns distribute evenly, Trade column logos vertically aligned (Uniswap vs Kyber)
- [ ] Recent Swaps: counterparty logos resolve for non-seed tokens via fallback CDNs (no gradient initials for common ERC-20s); Tx column shows truncated hash + full hash on hover
- [ ] Click-tracking still fires on Trade CTAs (preserved from the analytics commit)
- [ ] Type check clean: `npx tsc --noEmit` shows no errors in `src/(app|components|lib)/tokens/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)